### PR TITLE
CMake build scripts

### DIFF
--- a/DAMEE_4/scoord11/build_roms.csh
+++ b/DAMEE_4/scoord11/build_roms.csh
@@ -275,7 +275,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/DAMEE_4/scoord11/build_roms.csh
+++ b/DAMEE_4/scoord11/build_roms.csh
@@ -349,6 +349,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/DAMEE_4/scoord11/build_roms.csh
+++ b/DAMEE_4/scoord11/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DAMEE_4
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -429,7 +429,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/DAMEE_4/scoord11/build_roms.sh
+++ b/DAMEE_4/scoord11/build_roms.sh
@@ -350,6 +350,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/DAMEE_4/scoord11/build_roms.sh
+++ b/DAMEE_4/scoord11/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DAMEE_4
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -430,7 +430,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/DAMEE_4/scoord11/build_roms.sh
+++ b/DAMEE_4/scoord11/build_roms.sh
@@ -276,7 +276,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/DAMEE_4/scoord11/cbuild_roms.csh
+++ b/DAMEE_4/scoord11/cbuild_roms.csh
@@ -397,29 +397,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -627,9 +605,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -637,27 +615,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/DAMEE_4/scoord11/cbuild_roms.csh
+++ b/DAMEE_4/scoord11/cbuild_roms.csh
@@ -273,6 +273,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/DAMEE_4/scoord11/cbuild_roms.csh
+++ b/DAMEE_4/scoord11/cbuild_roms.csh
@@ -364,10 +364,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -568,7 +568,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/DAMEE_4/scoord11/cbuild_roms.csh
+++ b/DAMEE_4/scoord11/cbuild_roms.csh
@@ -321,6 +321,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/DAMEE_4/scoord11/cbuild_roms.sh
+++ b/DAMEE_4/scoord11/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DAMEE_4
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -353,7 +353,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -543,7 +543,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/DAMEE_4/scoord11/cbuild_roms.sh
+++ b/DAMEE_4/scoord11/cbuild_roms.sh
@@ -271,6 +271,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/DAMEE_4/scoord11/cbuild_roms.sh
+++ b/DAMEE_4/scoord11/cbuild_roms.sh
@@ -383,29 +383,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -596,20 +574,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/DAMEE_4/scoord11/cbuild_roms.sh
+++ b/DAMEE_4/scoord11/cbuild_roms.sh
@@ -307,6 +307,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/DAMEE_4/scoord22/build_roms.csh
+++ b/DAMEE_4/scoord22/build_roms.csh
@@ -275,7 +275,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/DAMEE_4/scoord22/build_roms.csh
+++ b/DAMEE_4/scoord22/build_roms.csh
@@ -349,6 +349,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/DAMEE_4/scoord22/build_roms.csh
+++ b/DAMEE_4/scoord22/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DAMEE_4
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -429,7 +429,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/DAMEE_4/scoord22/build_roms.sh
+++ b/DAMEE_4/scoord22/build_roms.sh
@@ -350,6 +350,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/DAMEE_4/scoord22/build_roms.sh
+++ b/DAMEE_4/scoord22/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DAMEE_4
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -430,7 +430,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/DAMEE_4/scoord22/build_roms.sh
+++ b/DAMEE_4/scoord22/build_roms.sh
@@ -276,7 +276,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/DAMEE_4/scoord22/cbuild_roms.csh
+++ b/DAMEE_4/scoord22/cbuild_roms.csh
@@ -397,29 +397,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -627,9 +605,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -637,27 +615,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/DAMEE_4/scoord22/cbuild_roms.csh
+++ b/DAMEE_4/scoord22/cbuild_roms.csh
@@ -273,6 +273,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/DAMEE_4/scoord22/cbuild_roms.csh
+++ b/DAMEE_4/scoord22/cbuild_roms.csh
@@ -364,10 +364,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -568,7 +568,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/DAMEE_4/scoord22/cbuild_roms.csh
+++ b/DAMEE_4/scoord22/cbuild_roms.csh
@@ -321,6 +321,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/DAMEE_4/scoord22/cbuild_roms.sh
+++ b/DAMEE_4/scoord22/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DAMEE_4
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -353,7 +353,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -543,7 +543,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/DAMEE_4/scoord22/cbuild_roms.sh
+++ b/DAMEE_4/scoord22/cbuild_roms.sh
@@ -271,6 +271,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/DAMEE_4/scoord22/cbuild_roms.sh
+++ b/DAMEE_4/scoord22/cbuild_roms.sh
@@ -383,29 +383,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -596,20 +574,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/DAMEE_4/scoord22/cbuild_roms.sh
+++ b/DAMEE_4/scoord22/cbuild_roms.sh
@@ -307,6 +307,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/External/varinfo.yaml
+++ b/External/varinfo.yaml
@@ -70,17 +70,6 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
-  - variable:       bath                                             # Input/Output
-    standard_name:  sea_floor_depth
-    long_name:      bathymetry
-    units:          meter                                            # [m]
-    field:          bathymetry
-    time:           ocean_time
-    index_code:     idbath
-    type:           r2dvar
-    add_offset:     0.0d0
-    scale:          1.0d0
-
   - variable:       zeta                                             # Input/Output
     standard_name:  sea_surface_height_above_geopotential_datum
     long_name:      free-surface
@@ -312,10 +301,333 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
+  #######################
+  ###  Grid Geometry  ###
+  #######################
+
+  - variable:       angle                                            # Input
+    standard_name:  grid_angle_of_rotation_from_east_to_y
+    long_name:      angle between XI-axis and EAST
+    units:          radians                                          # [rafians]
+    field:          angle
+    time:           nulvar
+    index_code:     idangR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       bath                                             # Input/Output
+    standard_name:  sea_floor_depth
+    long_name:      time-dependent bathymetry
+    units:          meter                                            # [m; positive]
+    field:          bathymetry
+    time:           ocean_time
+    index_code:     idbath
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       f                                                # Input
+    standard_name:  coriolis_parameter
+    long_name:      Coriolis parameter
+    units:          second-1                                         # [1/s]
+    field:          coriolis
+    time:           nulvar
+    index_code:     idfcor
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       h                                                # Input
+    standard_name:  sea_floor_depth
+    long_name:      time-independent bathymetry
+    units:          meter                                            # [m; positive]
+    field:          bathymetry
+    time:           nulvar
+    index_code:     idtopo
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_psi                                          # Input
+    standard_name:  grid_latitude_at_cell_corners
+    long_name:      latitude of PSI-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_psi
+    time:           nulvar
+    index_code:     idLatP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_rho                                          # Input
+    standard_name:  grid_latitude_at_cell_center
+    long_name:      latitude of RHO-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_rho
+    time:           nulvar
+    index_code:     idLatR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_u                                            # Input
+    standard_name:  grid_latitude_at_cell_y_edges
+    long_name:      latitude of U-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_u
+    time:           nulvar
+    index_code:     idLatU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_v                                            # Input
+    standard_name:  grid_latitude_at_cell_x_edges
+    long_name:      latitude of V-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_v
+    time:           nulvar
+    index_code:     idLatV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_psi                                          # Input
+    standard_name:  grid_longitude_at_cell_corners
+    long_name:      longitude of PSI-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_psi
+    time:           nulvar
+    index_code:     idLonP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_rho                                          # Input
+    standard_name:  grid_longitude_at_cell_center
+    long_name:      longitude of RHO-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_rho
+    time:           nulvar
+    index_code:     idLonR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_u                                            # Input
+    standard_name:  grid_longitude_at_cell_y_edges
+    long_name:      longitude of U-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_u
+    time:           nulvar
+    index_code:     idLonU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_v                                            # Input
+    standard_name:  grid_longitude_at_cell_x_edges
+    long_name:      longitude of V-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_v
+    time:           nulvar
+    index_code:     idLonV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_psi                                         # Input
+    standard_name:  land_sea_mask_at_cell_corners
+    long_name:      mask on PSI-points
+    units:          nondimensional
+    field:          mask_psi
+    time:           nulvar
+    index_code:     idmskP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_rho                                         # Input
+    standard_name:  land_sea_mask_at_cell_center
+    long_name:      mask on RHO-points
+    units:          nondimensional
+    field:          mask_rho
+    time:           nulvar
+    index_code:     idmskR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_u                                           # Input
+    standard_name:  land_sea_mask_at_cell_y_edges
+    long_name:      mask on U-points
+    units:          nondimensional
+    field:          mask_u
+    time:           nulvar
+    index_code:     idmskU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_v                                           # Input
+    standard_name:  land_sea_mask_at_cell_x_edges
+    long_name:      mask on V-points
+    units:          nondimensional
+    field:          mask_v
+    time:           nulvar
+    index_code:     idmskV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       pm                                               # Input
+    standard_name:  inverse_grid_x_spacing
+    long_name:      curvilinear coordinate metric in XI
+    units:          meter-1                                          # [1/m]
+    field:          pm
+    time:           nulvar
+    index_code:     idpmdx
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       pn                                               # Input
+    standard_name:  inverse_grid_y_spacing
+    long_name:      curvilinear coordinate metric in ETA
+    units:          meter-1                                          # [1/m]
+    field:          pn
+    time:           nulvar
+    index_code:     idpndy
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_rho                                        # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_center
+    long_name:      adjoint sensitivity spatial scope on RHO-points
+    units:          nondimensional
+    field:          scope_rho
+    time:           nulvar
+    index_code:     idscoR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_u                                          # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_y_edges
+    long_name:      adjoint sensitivity spatial scope on U-points
+    units:          nondimensional
+    field:          scope_u
+    time:           nulvar
+    index_code:     idscoU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_v                                          # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_x_edges
+    long_name:      adjoint sensitivity spatial scope on V-points
+    units:          nondimensional
+    field:          scope_v
+    time:           nulvar
+    index_code:     idscoV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_psi                                            # Input
+    standard_name:  grid_x_location_at_cell_corners
+    long_name:      x-locations of PSI-points
+    units:          meter                                            # [m]
+    field:          Xp
+    time:           nulvar
+    index_code:     idXgrP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_rho                                            # Input
+    standard_name:  grid_x_location_at_cell_center
+    long_name:      x-locations of RHO-points
+    units:          meter                                            # [m]
+    field:          Xr
+    time:           nulvar
+    index_code:     idXgrR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_u                                              # Input
+    standard_name:  grid_x_location_at_cell_y_edges
+    long_name:      x-locations of U-points
+    units:          meter                                            # [m]
+    field:          Xu
+    time:           nulvar
+    index_code:     idXgrU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_v                                              # Input
+    standard_name:  grid_x_location_at_cell_x_edges
+    long_name:      x-locations of V-points
+    units:          meter                                            # [m]
+    field:          Xv
+    time:           nulvar
+    index_code:     idXgrV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_psi                                            # Input
+    standard_name:  grid_y_location_at_cell_corners
+    long_name:      y-locations of PSI-points
+    units:          meter                                            # [m]
+    field:          Yp
+    time:           nulvar
+    index_code:     idYgrP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_rho                                            # Input
+    standard_name:  grid_y_location_at_cell_center
+    long_name:      y-locations of RHO-points
+    units:          meter                                            # [m]
+    field:          Yr
+    time:           nulvar
+    index_code:     idYgrR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_u                                              # Input
+    standard_name:  grid_y_location_at_cell_y_edges
+    long_name:      y-locations of U-points
+    units:          meter                                            # [m]
+    field:          Yu
+    time:           nulvar
+    index_code:     idYgrU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_v                                              # Input
+    standard_name:  grid_y_location_at_cell_x_edges
+    long_name:      y-locations of V-points
+    units:          meter                                            # [m]
+    field:          Yv
+    time:           nulvar
+    index_code:     idYgrV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
   - variable:       z_rho                                            # Output
     standard_name:  model_level_depth_at_cell_center
     long_name:      depth of RHO-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zr
     time:           ocean_time
     index_code:     idpthR
@@ -326,7 +638,7 @@ metadata:
   - variable:       z_u                                              # Output
     standard_name:  model_level_depth_at_cell_y_edges
     long_name:      depth of U-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zu
     time:           ocean_time
     index_code:     idpthU
@@ -337,7 +649,7 @@ metadata:
   - variable:       z_v                                              # Output
     standard_name:  model_level_depth_at_cell_x_edges
     long_name:      depth of V-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zv
     time:           ocean_time
     index_code:     idpthV
@@ -347,7 +659,7 @@ metadata:
 
   - variable:       z_w                                              # Output
     standard_name:  model_level_depth_at_cell_top_face
-    long_name:      depth of W-points                                # [m]
+    long_name:      depth of W-points                                # [m; negative]
     units:          meter
     field:          Zw
     time:           ocean_time
@@ -1578,7 +1890,7 @@ metadata:
     index_code:     idWdib
     type:           r2dvar
     add_offset:     0.0d0
-    scale:          1.0d0
+    scale:          0.00097561                                       # 1/rho0
 
   - variable:       Dissip_wcap                                      # Input
     standard_name:  sea_surface_wave_dissipation_due_to_whitecapping
@@ -1589,7 +1901,7 @@ metadata:
     index_code:     idWdiw
     type:           r2dvar
     add_offset:     0.0d0
-    scale:          1.0d0
+    scale:          0.00097561                                       # 1/rho0
 
   - variable:       Dissip_roller                                    # Input
     standard_name:  sea_surface_wave_roller_dissipation
@@ -1600,7 +1912,7 @@ metadata:
     index_code:     idWdis
     type:           r2dvar
     add_offset:     0.0d0
-    scale:          1.0d0
+    scale:          0.00097561                                       # 1/rho0
 
   - variable:       roller_action                                    # Input
     standard_name:  sea_surface_wave_roller_action_density

--- a/External/varinfo_daily.yaml
+++ b/External/varinfo_daily.yaml
@@ -70,17 +70,6 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
-  - variable:       bath                                             # Input/Output
-    standard_name:  sea_floor_depth
-    long_name:      bathymetry
-    units:          meter                                            # [m]
-    field:          bathymetry
-    time:           ocean_time
-    index_code:     idbath
-    type:           r2dvar
-    add_offset:     0.0d0
-    scale:          1.0d0
-
   - variable:       zeta                                             # Input/Output
     standard_name:  sea_surface_height_above_geopotential_datum
     long_name:      free-surface
@@ -312,10 +301,333 @@ metadata:
     add_offset:     0.0d0
     scale:          1.0d0
 
+  #######################
+  ###  Grid Geometry  ###
+  #######################
+
+  - variable:       angle                                            # Input
+    standard_name:  grid_angle_of_rotation_from_east_to_y
+    long_name:      angle between XI-axis and EAST
+    units:          radians                                          # [rafians]
+    field:          angle
+    time:           nulvar
+    index_code:     idangR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       bath                                             # Input/Output
+    standard_name:  sea_floor_depth
+    long_name:      time-dependent bathymetry
+    units:          meter                                            # [m; positive]
+    field:          bathymetry
+    time:           ocean_time
+    index_code:     idbath
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       f                                                # Input
+    standard_name:  coriolis_parameter
+    long_name:      Coriolis parameter
+    units:          second-1                                         # [1/s]
+    field:          coriolis
+    time:           nulvar
+    index_code:     idfcor
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       h                                                # Input
+    standard_name:  sea_floor_depth
+    long_name:      time-independent bathymetry
+    units:          meter                                            # [m; positive]
+    field:          bathymetry
+    time:           nulvar
+    index_code:     idtopo
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_psi                                          # Input
+    standard_name:  grid_latitude_at_cell_corners
+    long_name:      latitude of PSI-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_psi
+    time:           nulvar
+    index_code:     idLatP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_rho                                          # Input
+    standard_name:  grid_latitude_at_cell_center
+    long_name:      latitude of RHO-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_rho
+    time:           nulvar
+    index_code:     idLatR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_u                                            # Input
+    standard_name:  grid_latitude_at_cell_y_edges
+    long_name:      latitude of U-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_u
+    time:           nulvar
+    index_code:     idLatU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lat_v                                            # Input
+    standard_name:  grid_latitude_at_cell_x_edges
+    long_name:      latitude of V-points
+    units:          degree_north                                     # [degree_north]
+    field:          lat_v
+    time:           nulvar
+    index_code:     idLatV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_psi                                          # Input
+    standard_name:  grid_longitude_at_cell_corners
+    long_name:      longitude of PSI-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_psi
+    time:           nulvar
+    index_code:     idLonP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_rho                                          # Input
+    standard_name:  grid_longitude_at_cell_center
+    long_name:      longitude of RHO-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_rho
+    time:           nulvar
+    index_code:     idLonR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_u                                            # Input
+    standard_name:  grid_longitude_at_cell_y_edges
+    long_name:      longitude of U-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_u
+    time:           nulvar
+    index_code:     idLonU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       lon_v                                            # Input
+    standard_name:  grid_longitude_at_cell_x_edges
+    long_name:      longitude of V-points
+    units:          degree_east                                      # [degree_east]
+    field:          lon_v
+    time:           nulvar
+    index_code:     idLonV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_psi                                         # Input
+    standard_name:  land_sea_mask_at_cell_corners
+    long_name:      mask on PSI-points
+    units:          nondimensional
+    field:          mask_psi
+    time:           nulvar
+    index_code:     idmskP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_rho                                         # Input
+    standard_name:  land_sea_mask_at_cell_center
+    long_name:      mask on RHO-points
+    units:          nondimensional
+    field:          mask_rho
+    time:           nulvar
+    index_code:     idmskR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_u                                           # Input
+    standard_name:  land_sea_mask_at_cell_y_edges
+    long_name:      mask on U-points
+    units:          nondimensional
+    field:          mask_u
+    time:           nulvar
+    index_code:     idmskU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       mask_v                                           # Input
+    standard_name:  land_sea_mask_at_cell_x_edges
+    long_name:      mask on V-points
+    units:          nondimensional
+    field:          mask_v
+    time:           nulvar
+    index_code:     idmskV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       pm                                               # Input
+    standard_name:  inverse_grid_x_spacing
+    long_name:      curvilinear coordinate metric in XI
+    units:          meter-1                                          # [1/m]
+    field:          pm
+    time:           nulvar
+    index_code:     idpmdx
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       pn                                               # Input
+    standard_name:  inverse_grid_y_spacing
+    long_name:      curvilinear coordinate metric in ETA
+    units:          meter-1                                          # [1/m]
+    field:          pn
+    time:           nulvar
+    index_code:     idpndy
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_rho                                        # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_center
+    long_name:      adjoint sensitivity spatial scope on RHO-points
+    units:          nondimensional
+    field:          scope_rho
+    time:           nulvar
+    index_code:     idscoR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_u                                          # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_y_edges
+    long_name:      adjoint sensitivity spatial scope on U-points
+    units:          nondimensional
+    field:          scope_u
+    time:           nulvar
+    index_code:     idscoU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       scope_v                                          # Input
+    standard_name:  adjoint_sensitivity_scope_mask_at_cell_x_edges
+    long_name:      adjoint sensitivity spatial scope on V-points
+    units:          nondimensional
+    field:          scope_v
+    time:           nulvar
+    index_code:     idscoV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_psi                                            # Input
+    standard_name:  grid_x_location_at_cell_corners
+    long_name:      x-locations of PSI-points
+    units:          meter                                            # [m]
+    field:          Xp
+    time:           nulvar
+    index_code:     idXgrP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_rho                                            # Input
+    standard_name:  grid_x_location_at_cell_center
+    long_name:      x-locations of RHO-points
+    units:          meter                                            # [m]
+    field:          Xr
+    time:           nulvar
+    index_code:     idXgrR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_u                                              # Input
+    standard_name:  grid_x_location_at_cell_y_edges
+    long_name:      x-locations of U-points
+    units:          meter                                            # [m]
+    field:          Xu
+    time:           nulvar
+    index_code:     idXgrU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       x_v                                              # Input
+    standard_name:  grid_x_location_at_cell_x_edges
+    long_name:      x-locations of V-points
+    units:          meter                                            # [m]
+    field:          Xv
+    time:           nulvar
+    index_code:     idXgrV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_psi                                            # Input
+    standard_name:  grid_y_location_at_cell_corners
+    long_name:      y-locations of PSI-points
+    units:          meter                                            # [m]
+    field:          Yp
+    time:           nulvar
+    index_code:     idYgrP
+    type:           p2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_rho                                            # Input
+    standard_name:  grid_y_location_at_cell_center
+    long_name:      y-locations of RHO-points
+    units:          meter                                            # [m]
+    field:          Yr
+    time:           nulvar
+    index_code:     idYgrR
+    type:           r2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_u                                              # Input
+    standard_name:  grid_y_location_at_cell_y_edges
+    long_name:      y-locations of U-points
+    units:          meter                                            # [m]
+    field:          Yu
+    time:           nulvar
+    index_code:     idYgrU
+    type:           u2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
+  - variable:       y_v                                              # Input
+    standard_name:  grid_y_location_at_cell_x_edges
+    long_name:      y-locations of V-points
+    units:          meter                                            # [m]
+    field:          Yv
+    time:           nulvar
+    index_code:     idYgrV
+    type:           v2dvar
+    add_offset:     0.0d0
+    scale:          1.0d0
+
   - variable:       z_rho                                            # Output
     standard_name:  model_level_depth_at_cell_center
     long_name:      depth of RHO-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zr
     time:           ocean_time
     index_code:     idpthR
@@ -326,7 +638,7 @@ metadata:
   - variable:       z_u                                              # Output
     standard_name:  model_level_depth_at_cell_y_edges
     long_name:      depth of U-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zu
     time:           ocean_time
     index_code:     idpthU
@@ -337,7 +649,7 @@ metadata:
   - variable:       z_v                                              # Output
     standard_name:  model_level_depth_at_cell_x_edges
     long_name:      depth of V-points
-    units:          meter                                            # [m]
+    units:          meter                                            # [m; negative]
     field:          Zv
     time:           ocean_time
     index_code:     idpthV
@@ -347,7 +659,7 @@ metadata:
 
   - variable:       z_w                                              # Output
     standard_name:  model_level_depth_at_cell_top_face
-    long_name:      depth of W-points                                # [m]
+    long_name:      depth of W-points                                # [m; negative]
     units:          meter
     field:          Zw
     time:           ocean_time
@@ -1578,7 +1890,7 @@ metadata:
     index_code:     idWdib
     type:           r2dvar
     add_offset:     0.0d0
-    scale:          1.0d0
+    scale:          0.00097561                                       # 1/rho0
 
   - variable:       Dissip_wcap                                      # Input
     standard_name:  sea_surface_wave_dissipation_due_to_whitecapping
@@ -1589,7 +1901,7 @@ metadata:
     index_code:     idWdiw
     type:           r2dvar
     add_offset:     0.0d0
-    scale:          1.0d0
+    scale:          0.00097561                                       # 1/rho0
 
   - variable:       Dissip_roller                                    # Input
     standard_name:  sea_surface_wave_roller_dissipation
@@ -1600,7 +1912,7 @@ metadata:
     index_code:     idWdis
     type:           r2dvar
     add_offset:     0.0d0
-    scale:          1.0d0
+    scale:          0.00097561                                       # 1/rho0
 
   - variable:       roller_action                                    # Input
     standard_name:  sea_surface_wave_roller_action_density

--- a/IRENE/Coupled_RBL4DVAR/build_split.csh
+++ b/IRENE/Coupled_RBL4DVAR/build_split.csh
@@ -182,7 +182,7 @@ setenv ROMS_APPLICATION      IRENE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -529,7 +529,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/IRENE/Coupled_RBL4DVAR/build_split.sh
+++ b/IRENE/Coupled_RBL4DVAR/build_split.sh
@@ -138,7 +138,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -183,9 +183,9 @@ export   ROMS_APPLICATION=IRENE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -525,7 +525,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/IRENE/Coupling/build_roms.csh
+++ b/IRENE/Coupling/build_roms.csh
@@ -353,6 +353,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/IRENE/Coupling/build_roms.csh
+++ b/IRENE/Coupling/build_roms.csh
@@ -278,8 +278,8 @@ endif
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-#setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF.4.3
- setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+#setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF.4.3
+ setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/IRENE/Coupling/build_roms.csh
+++ b/IRENE/Coupling/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      IRENE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -433,7 +433,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/IRENE/Coupling/build_roms.sh
+++ b/IRENE/Coupling/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=IRENE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -434,7 +434,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/IRENE/Coupling/build_roms.sh
+++ b/IRENE/Coupling/build_roms.sh
@@ -279,8 +279,8 @@ fi
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-#export       WRF_SRC_DIR=${HOME}/ocean/repository/WRF.4.3
- export       WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+#export       WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF.4.3
+ export       WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/IRENE/Coupling/build_roms.sh
+++ b/IRENE/Coupling/build_roms.sh
@@ -354,6 +354,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/IRENE/Coupling/cbuild_roms.csh
+++ b/IRENE/Coupling/cbuild_roms.csh
@@ -1,0 +1,680 @@
+#!/bin/csh -ef
+#
+# git $Id$
+# svn $Id: cbuild_roms.csh 1189 2023-08-15 21:26:58Z arango $
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+# Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
+#   Licensed under a MIT/X style license                                :::
+#   See License_ROMS.txt                                                :::
+#::::::::::::::::::::::::::::::::::::::::::::::::::::: Hernan G. Arango :::
+#                                                                       :::
+# ROMS CMake Compiling CSH Script                                       :::
+#                                                                       :::
+# Script to compile an user application where the application-specific  :::
+# files are kept separate from the ROMS source code.                    :::
+#                                                                       :::
+# Q: How/why does this script work?                                     :::
+#                                                                       :::
+# A: The ROMS makefile configures user-defined options with a set of    :::
+#    flags such as ROMS_APPLICATION. Browse the makefile to see these.  :::
+#    If an option in the makefile uses the syntax ?= in setting the     :::
+#    default, this means that make will check whether an environment    :::
+#    variable by that name is set in the shell that calls make. If so   :::
+#    the environment variable value overrides the default (and the      :::
+#    user need not maintain separate makefiles, or frequently edit      :::
+#    the makefile, to run separate applications).                       :::
+#                                                                       :::
+# Usage:                                                                :::
+#                                                                       :::
+#    ./cbuild_roms.csh [options]                                        :::
+#                                                                       :::
+# Options:                                                              :::
+#                                                                       :::
+#    -j [N]         Compile in parallel using N CPUs                    :::
+#                     omit argument for all available CPUs              :::
+#                                                                       :::
+#    -b             Compile a specific ROMS GitHub branch               :::
+#                                                                       :::
+#                     cbuild_roms.csh -j 5 -b feature/kernel            :::
+#                                                                       :::
+#    -p macro       Prints any Makefile macro value. For example,       :::
+#                                                                       :::
+#                     cbuild_roms.csh -p MY_CPP_FLAGS                   :::
+#                                                                       :::
+#    -noclean       Do not clean already compiled objects               :::
+#                                                                       :::
+#    -v             Compile in verbose mode (VERBOSE=1)                 :::
+#                                                                       :::
+# The branch option -b is only possible for ROMS source code from       :::
+# https://github.com/myroms. Such versions are under development        :::
+# and targeted to advanced users, superusers, and beta testers.         :::
+# Regular and novice users must use the default 'develop' branch.       :::
+#                                                                       :::
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+setenv which_MPI openmpi                      #  default, overwritten below
+
+set parallel = 0
+set clean = 1
+set dprint = 0
+set Verbose = 0
+set branch = 0
+
+set command = "cbuild_roms.csh $argv[*]"
+
+set separator = `perl -e "print '<>' x 50;"`
+
+setenv MY_CPP_FLAGS ''
+
+while ( ($#argv) > 0 )
+  switch ($1)
+    case "-j"
+      shift
+      set parallel = 1
+      if (`echo $1 | grep '^[0-9]\+$'` != "" ) then
+        set NCPUS = "-j $1"
+        shift
+      else
+        set NCPUS = "-j"
+      endif
+    breaksw
+
+    case "-p"
+      shift
+      set clean = 0
+      set dprint = 1
+      set debug = "$1"
+      shift
+    breaksw
+
+    case "-v"
+      shift
+      set Verbose = 1
+    breaksw
+
+    case "-noclean"
+      shift
+      set clean = 0
+    breaksw
+
+    case "-b"
+      shift
+      set branch = 1
+      set branch_name = `echo $1 | grep -v '^-'`
+      if ( "$branch_name" == "" ) then
+        echo "Please enter a branch name."
+        exit 1
+      endif
+      shift
+    breaksw
+
+    case "-*":
+      echo ""
+      echo "${separator}"
+      echo "$0 : Unknown option [ $1 ]"
+      echo ""
+      echo "Available Options:"
+      echo ""
+      echo "-j [N]          Compile in parallel using N CPUs"
+      echo "                  omit argument for all avaliable CPUs"
+      echo ""
+      echo "-b branch_name  Compile specific ROMS GitHub branch name"
+      echo "                  For example:  cbuild_roms.csh -b feature/kernel"
+      echo ""
+      echo "-p macro        Prints any Makefile macro value"
+      echo "                  For example:  cbuild_roms.csh -p FFLAGS"
+      echo ""
+      echo "-noclean        Do not clean already compiled objects"
+      echo ""
+      echo "-v              Compile in verbose mode"
+      echo "${separator}"
+      echo ""
+      exit 1
+    breaksw
+
+  endsw
+end
+
+# Set the CPP option defining the particular application. This will
+# determine the name of the ".h" header file with the application
+# CPP definitions. REQUIRED
+
+ setenv ROMS_APPLICATION     IRENE
+
+# Set a local environmental variable to define the path to the directories
+# where the ROMS source code is located (MY_ROOT_DIR), and this project's
+# configuration and files are kept (MY_PROJECT_DIR). Notice that if the
+# User sets the ROMS_ROOT_DIR environment variable in their computer logging
+# script describing the location from where the ROMS source code was cloned
+# or downloaded, it uses that value.
+
+if ( $?ROMS_ROOT_DIR ) then
+  if ( "${ROMS_ROOT_DIR}" != "" ) then
+    setenv MY_ROOT_DIR       ${ROMS_ROOT_DIR}
+  else
+    setenv MY_ROOT_DIR       ${HOME}/ocean/repository/git
+  endif
+else
+  setenv MY_ROOT_DIR         ${HOME}/ocean/repository/git
+endif
+
+setenv MY_PROJECT_DIR        ${PWD}
+
+# The path to the user's local current ROMS source code.
+#
+# If downloading ROMS locally, this would be the user's Working Copy Path.
+# One advantage of maintaining your source code copy is that when working
+# simultaneously on multiple machines (e.g., a local workstation, a local
+# cluster, and a remote supercomputer), you can update with the latest ROMS
+# release and always get an up-to-date customized source on each machine.
+# This script allows for differing paths to the code and inputs on other
+# computers.
+
+ setenv MY_ROMS_SRC          ${MY_ROOT_DIR}/roms
+
+# Which type(s) of libraries would you like?
+#
+# NOTE: If you choose both and also choose to build the ROMS executable,
+#       it will be linked to the static version of the library.
+#
+# Valid options are SHARED, STATIC, and BOTH.
+
+ setenv LIBTYPE              STATIC
+
+# Do you want to build the ROMS executable?
+#
+# Valid values are: ON (build the executable) and OFF (do NOT build the
+# executable). If you comment this out the executable WILL be built.
+
+ setenv ROMS_EXECUTABLE      ON
+
+# Set path of the directory containing "my_build_paths.csh".
+#
+# The user has the option to specify a customized version of this file
+# in a different directory than the one distributed with the source code,
+# ${MY_ROMS_SRC}/Compilers. If this is the case, you need to keep this
+# configurations files up-to-date.
+
+ setenv COMPILERS            ${MY_ROMS_SRC}/Compilers
+#setenv COMPILERS            ${HOME}/Compilers/ROMS
+
+#--------------------------------------------------------------------------
+# Set tunable CPP options.
+#--------------------------------------------------------------------------
+#
+# Sometimes it is desirable to activate one or more CPP options to run
+# different variants of the same application without modifying its header
+# file. If this is the case, specify each option here.
+#
+# Notice also that you need to use shell's quoting syntax to enclose the
+# definition.
+#
+#    setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DAVERAGES"
+#    setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DDEBUGGING"
+#
+# can be used to write time-averaged fields. Notice that you can have as
+# many definitions as you want by appending values.
+
+ set bulk_flux = 0                # use WRF atmosphere boundary layer
+#set bulk_flux = 1                # use ROMS bulk fluxes formulation
+
+if ( $bulk_flux == 1 ) then
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DBULK_FLUXES"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DCOOL_SKIN"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DEMINUSP"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DLONGWAVE_OUT"
+endif
+
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DWIND_MINUS_CURRENT"
+
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DESMF_LIB"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DDATA_COUPLING"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DWRF_COUPLING"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DWRF_TIMEAVG"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DFRC_COUPLING"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DROMS_STDOUT"
+
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DVERIFICATION"
+
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DCOLLECT_ALLREDUCE"
+#setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DREDUCE_ALLGATHER"
+
+#setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DDEBUGGING"
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DOUT_DOUBLE"
+#setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DPOSITIVE_ZERO"
+
+#--------------------------------------------------------------------------
+# Compilation options.
+#--------------------------------------------------------------------------
+
+ setenv USE_MPI              on              # distributed-memory
+ setenv USE_MPIF90           on              # compile with mpif90 script
+#setenv which_MPI            intel           # compile with mpiifort library
+#setenv which_MPI            mpich           # compile with MPICH library
+#setenv which_MPI            mpich2          # compile with MPICH2 library
+#setenv which_MPI            mvapich2        # compile with MVAPICH2 library
+ setenv which_MPI            openmpi         # compile with OpenMPI library
+
+ setenv FORT                 ifort
+#setenv FORT                 gfortran
+#setenv FORT                 pgi
+
+#setenv USE_DEBUG            on              # use Fortran debugging flags
+
+# ROMS I/O choices and combinations. A more complete description of the
+# available options can be found in the wiki (https://myroms.org/wiki/IO).
+# Most users will want to enable at least USE_NETCDF4 because that will
+# instruct the ROMS build system to use nf-config to determine the
+# necessary libraries and paths to link into the ROMS executable.
+
+ setenv USE_NETCDF4          on              # compile with NetCDF4 library
+#setenv USE_PARALLEL_IO      on              # Parallel I/O with NetCDF-4/HDF5
+#setenv USE_PIO              on              # Parallel I/O with PIO library
+#setenv USE_SCORPIO          on              # Parallel I/O with SCORPIO library
+
+# If any of the coupling component use the HDF5 Fortran API for primary
+# I/O, we need to compile the main driver with the HDF5 library.
+
+#setenv USE_HDF5             on              # compile with HDF5 library
+
+#--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
+# If applicable, use my specified library paths.
+#--------------------------------------------------------------------------
+
+ setenv USE_MY_LIBS no           # use system default library paths
+#setenv USE_MY_LIBS yes          # use my customized library paths
+
+set MY_PATHS = ${COMPILERS}/my_build_paths.csh
+
+if ($USE_MY_LIBS == 'yes') then
+  source ${MY_PATHS} ${MY_PATHS}
+endif
+
+# Set location of the application header file.
+
+ setenv MY_HEADER_DIR        ${MY_PROJECT_DIR}
+
+# If you have custom analytical functions to include, enter the path here.
+
+ setenv MY_ANALYTICAL_DIR    ${MY_PROJECT_DIR}
+
+ echo ""
+ echo "${separator}"
+
+# Put the CMake files in a project specific Build directory to avoid conflict
+# with other projects.
+
+if ( $?USE_DEBUG ) then
+  if ( "${USE_DEBUG}" == "on" ) then
+    setenv BUILD_DIR         ${MY_PROJECT_DIR}/CBuild_romsG
+  else if ( $?USE_MPI ) then
+    if ( "${USE_MPI}" == "on" ) then
+      setenv BUILD_DIR       ${MY_PROJECT_DIR}/CBuild_romsM
+    else
+      setenv BUILD_DIR       ${MY_PROJECT_DIR}/CBuild_roms
+    endif
+  else
+    setenv BUILD_DIR         ${MY_PROJECT_DIR}/CBuild_roms
+  endif
+else if ($?USE_MPI) then
+  if ( "${USE_MPI}" == "on" ) then
+    setenv BUILD_DIR         ${MY_PROJECT_DIR}/CBuild_romsM
+  else
+    setenv BUILD_DIR         ${MY_PROJECT_DIR}/CBuild_roms
+  endif
+else
+  setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
+endif
+
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
+# If necessary, create ROMS build directory.
+
+if ( $dprint == 0 ) then
+  if ( -d ${BUILD_DIR} ) then
+    if ( $clean == 1 ) then
+      echo ""
+      echo "Removing ROMS build directory: ${BUILD_DIR}"
+      echo ""
+      rm -rf ${BUILD_DIR}
+      echo ""
+      echo "Creating ROMS build directory: ${BUILD_DIR}"
+      echo ""
+      mkdir ${BUILD_DIR}
+    endif
+  else
+    if ( $clean == 1 ) then
+      mkdir ${BUILD_DIR}
+      cd ${BUILD_DIR}
+    else
+      echo ""
+      echo "Option -noclean activated when the ROMS build directory didn't exist"
+      echo "Creating ROMS build directory and disabling -noclean"
+      echo ""
+      set clean = 1
+      mkdir ${BUILD_DIR}
+      cd ${BUILD_DIR}
+    endif
+  endif
+
+  # If requested, check out requested branch from ROMS GitHub
+
+  if ( $branch == 1 ) then
+    if ( ! -d ${MY_PROJECT_DIR}/src ) then
+      echo ""
+      echo "Downloading ROMS source code from GitHub: https://www.github.com/myroms"
+      echo ""
+      git clone https://www.github.com/myroms/roms.git src
+    endif
+    echo ""
+    echo "Checking out ROMS GitHub branch: $branch_name"
+    echo ""
+    cd src
+    git checkout $branch_name
+  
+    # If we are using the COMPILERS from the ROMS source code
+    # overide the value set above
+  
+    if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
+      setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
+    endif
+    setenv MY_ROMS_SRC ${MY_PROJECT_DIR}/src
+
+  else
+    echo ""
+    echo "Using ROMS source code from: ${MY_ROMS_SRC}"
+    echo ""
+    cd ${MY_ROMS_SRC}
+  endif
+endif
+
+#--------------------------------------------------------------------------
+# Add environmental variables constructed in 'makefile' to MY_CPP_FLAGS
+# so can be passed to ROMS.
+#--------------------------------------------------------------------------
+
+set ANALYTICAL_DIR = "ANALYTICAL_DIR='${MY_ANALYTICAL_DIR}'"
+set HEADER = `echo ${ROMS_APPLICATION} | tr '[:upper:]' '[:lower:]'`.h
+set HEADER_DIR = "HEADER_DIR='${MY_HEADER_DIR}'"
+set ROOT_DIR = "ROOT_DIR='${MY_ROMS_SRC}'"
+
+set mycppflags = "${MY_CPP_FLAGS}"
+
+setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
+setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
+setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
+
+cd ${BUILD_DIR}
+
+#--------------------------------------------------------------------------
+# Configure.
+#--------------------------------------------------------------------------
+
+# Construct the cmake command.
+
+if ( $?LIBTYPE ) then
+  set ltype="-DLIBTYPE=${LIBTYPE}"
+else
+  set ltype=""
+endif
+
+if ( $?FORT ) then
+  if ( "${FORT}" == "ifort" ) then
+    set compiler="-DCMAKE_Fortran_COMPILER=ifort"
+  else if ( "${FORT}" == "gfortran" ) then
+    set compiler="-DCMAKE_Fortran_COMPILER=gfortran"
+  else
+    set compiler=""
+  endif
+endif
+
+if ( $?MY_CPP_FLAGS ) then
+  set tmp=`echo ${MY_CPP_FLAGS} | sed 's/^ *-D//' | sed 's/ *-D/;/g'`
+  set extra_flags="-DMY_CPP_FLAGS=${tmp}"
+else
+  set extra_flags=""
+endif
+
+if ( $?PARPACK_LIBDIR ) then
+  set parpack_ldir="-DPARPACK_LIBDIR=${PARPACK_LIBDIR}"
+else
+  set parpack_ldir=""
+endif
+
+if ( $?ARPACK_LIBDIR ) then
+  set arpack_ldir="-DARPACK_LIBDIR=${ARPACK_LIBDIR}"
+else
+  set arpack_ldir=""
+endif
+
+if ( $?PIO_LIBDIR && $?PIO_INCDIR ) then
+  set pio_ldir="-DPIO_LIBDIR=${PIO_LIBDIR}"
+  set pio_idir="-DPIO_INCDIR=${PIO_INCDIR}"
+  if ( $?PNETCDF_LIBDIR && $?PNETCDF_INCDIR ) then
+    set pnetcdf_ldir="-DPNETCDF_LIBDIR=${PNETCDF_LIBDIR}"
+    set pnetcdf_idir="-DPNETCDF_INCDIR=${PNETCDF_INCDIR}"
+  else
+    set pnetcdf_ldir=""
+    set pnetcdf_idir=""
+  endif
+else
+  set pio_ldir=""
+  set pio_idir=""
+  set pnetcdf_ldir=""
+  set pnetcdf_idir=""
+endif
+
+# The nested ifs are required to avoid breaking the script, as tcsh
+# apparently does not short-circuit if when the first truth is found
+
+if ( $?USE_MPI ) then
+  if ( "${USE_MPI}" == "on" ) then
+    set mpi="-DMPI=ON"
+  else
+    set mpi=""
+  endif
+else
+  set mpi=""
+endif
+
+if ( $?USE_MPIF90 ) then
+  if ( "${USE_MPIF90}" == "on" ) then
+    set comm="-DCOMM=${which_MPI}"
+  else
+    set comm=""
+  endif
+else
+  set comm=""
+endif
+
+if ( $?ROMS_EXECUTABLE ) then
+  if ( "${ROMS_EXECUTABLE}" == "ON" ) then
+    set roms_exec="-DROMS_EXECUTABLE=ON"
+  else
+    set roms_exec="-DROMS_EXECUTABLE=OFF"
+  endif
+else
+  set roms_exec=""
+endif
+
+if ( $?USE_DEBUG ) then
+  if ( "${USE_DEBUG}" == "on" ) then
+    set dbg="-DCMAKE_BUILD_TYPE=Debug"
+  else
+    set dbg="-DCMAKE_BUILD_TYPE=Release"
+  endif
+else
+  set dbg="-DCMAKE_BUILD_TYPE=Release"
+endif
+
+#--------------------------------------------------------------------------
+# Run the chosen build command.
+#--------------------------------------------------------------------------
+
+set my_hdir="-DMY_HEADER_DIR=${MY_HEADER_DIR}"
+
+if ( $dprint == 0 ) then
+  if ( $clean == 1 ) then
+    echo ""
+    echo "Configuring CMake for ROMS application:"
+    echo ""
+    cmake -DROMS_APP=${ROMS_APPLICATION} \
+                     ${my_hdir} \
+                     ${ltype} \
+                     ${compiler} \
+                     ${extra_flags} \
+                     ${parpack_ldir} \
+                     ${arpack_ldir} \
+                     ${pio_ldir} \
+                     ${pio_idir} \
+                     ${pnetcdf_ldir} \
+                     ${pnetcdf_idir} \
+                     ${mpi} \
+                     ${comm} \
+                     ${roms_exec} \
+                     ${dbg} \
+                     ${MY_ROMS_SRC}
+  endif
+endif
+
+#--------------------------------------------------------------------------
+# Compile.
+#--------------------------------------------------------------------------
+
+if ( $dprint == 1 ) then
+  set val = `eval echo \$${debug}`
+  echo "${debug}:$val"
+else
+
+  echo ""
+  echo "Compiling ROMS source code:"
+  echo ""
+
+  if ( $parallel == 1 ) then
+    if ( $Verbose == 1 ) then
+      make VERBOSE=1 $NCPUS
+    else
+      make $NCPUS
+    endif
+  else
+    if ( $Verbose == 1 ) then
+      make VERBOSE=1
+    else
+      make
+    endif
+  endif
+  make install
+
+  echo ""
+  echo "${separator}"
+  echo "CMake Build script command:    ${command}"
+  echo "ROMS source directory:         ${MY_ROMS_SRC}"
+  echo "ROMS build  directory:         ${BUILD_DIR}"
+  if ( $branch == 1 ) then
+    echo "ROMS downloaded from:          https://github.com/myroms/roms.git"
+    echo "ROMS compiled branch:          $branch_name"
+  endif
+  echo "ROMS Application:              ${ROMS_APPLICATION}"
+  set FFLAGS = `cat fortran_flags`
+  echo "Fortran compiler:              ${FORT}"
+  echo "Fortran flags:                 ${FFLAGS}"
+  if ($?mycppflags) then
+    echo "Added CPP Options:            ${mycppflags}"
+  endif
+  echo "${separator}"
+  echo ""
+endif
+
+cd ${MY_PROJECT_DIR}
+
+# If ROMS_EXECUTABLE is set to OFF remove the symlink from
+# previous build if present.
+
+if ( $?ROMS_EXECUTABLE ) then
+  if ( "${ROMS_EXECUTABLE}" == "OFF" ) then
+    if ( $?USE_DEBUG ) then
+      if ( "${USE_DEBUG}" == "on" ) then
+        if { test -L romsG } then
+          rm -f romsG
+        endif
+      endif
+    else if ( $?USE_MPI ) then
+      if ( "${USE_MPI}" == "on" ) then
+        if { test  -L romsM } then
+          rm -f romsM
+        endif
+      endif
+    else
+      if { test -L romsS } then
+        rm -f romsS
+      endif
+    endif
+  endif
+endif
+
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# RPATH/RUNPATH are set correctly for both the build tree and
+# installed locations of the ROMS executable.
+
+if ( $dprint == 0 ) then
+  if ( ! $?ROMS_EXECUTABLE ) then
+    if ( $?USE_DEBUG ) then
+      if ( "${USE_DEBUG}" == "on" ) then
+        cp -pfv ${BUILD_DIR}/romsG .
+      endif
+    else if ( $?USE_MPI ) then
+      if ( "${USE_MPI}" == "on" ) then
+        cp -pfv ${BUILD_DIR}/romsM .
+      endif
+    else
+      cp -pfv ${BUILD_DIR}/romsS .
+    endif
+  else
+    if ( "${ROMS_EXECUTABLE}" == "ON" ) then
+      if ( $?USE_DEBUG ) then
+        if ( "${USE_DEBUG}" == "on" ) then
+          cp -pfv ${BUILD_DIR}/romsG .
+        endif
+      else if ( $?USE_MPI ) then
+        if ( "${USE_MPI}" == "on" ) then
+          cp -pfv ${BUILD_DIR}/romsM .
+        endif
+      else
+        cp -pfv ${BUILD_DIR}/romsS .
+      endif
+    endif
+  endif
+endif

--- a/IRENE/Coupling/cbuild_roms.sh
+++ b/IRENE/Coupling/cbuild_roms.sh
@@ -1,0 +1,631 @@
+#!/bin/bash
+#
+# git $Id$
+# svn $Id: cbuild_roms.sh 1189 2023-08-15 21:26:58Z arango $
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+# Copyright (c) 2002-2023 The ROMS/TOMS Group                           :::
+#   Licensed under a MIT/X style license                                :::
+#   See License_ROMS.txt                                                :::
+#:::::::::::::::::::::::::::::::::::::::::::::::::::::: David Robertson :::
+#                                                                       :::
+# ROMS CMake Compiling BASH Script                                      :::
+#                                                                       :::
+# Script to configure and compile a user application where the          :::
+# application-specific files are kept separate from the ROMS            :::
+# source code.                                                          :::
+#                                                                       :::
+# Q: How/why does this script work?                                     :::
+#                                                                       :::
+# A: The ROMS makefile configures user-defined options with a set of    :::
+#    flags such as ROMS_APPLICATION. Browse the makefile to see these.  :::
+#    If an option in the makefile uses the syntax ?= in setting the     :::
+#    default, this means that make will check whether an environment    :::
+#    variable by that name is set in the shell that calls make. If so   :::
+#    the environment variable value overrides the default (and the      :::
+#    user need not maintain separate makefiles, or frequently edit      :::
+#    the makefile, to run separate applications).                       :::
+#                                                                       :::
+# Usage:                                                                :::
+#                                                                       :::
+#    ./cbuild_roms.sh [options]                                         :::
+#                                                                       :::
+# Options:                                                              :::
+#                                                                       :::
+#    -j [N]         Compile in parallel using N CPUs                    :::
+#                     omit argument for all available CPUs              :::
+#                                                                       :::
+#    -b             Compile a specific ROMS GitHub branch               :::
+#                                                                       :::
+#                     cbuild_roms.sh -j 5 -b feature/kernel             :::
+#                                                                       :::
+#    -p macro       Prints any Makefile macro value. For example,       :::
+#                                                                       :::
+#                     cbuild_roms.sh -p MY_CPP_FLAGS                    :::
+#                                                                       :::
+#    -noclean       Do not clean already compiled objects               :::
+#                                                                       :::
+#    -v             Compile in verbose mode (VERBOSE=1)                 :::
+#                                                                       :::
+# The branch option -b is only possible for ROMS source code from       :::
+# https://github.com/myroms. Such versions are under development        :::
+# and targeted to advanced users, superusers, and beta testers.         :::
+# Regular and novice users must use the default 'develop' branch.       :::
+#                                                                       :::
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+export which_MPI=openmpi                       # default, overwritten below
+
+parallel=0
+clean=1
+dprint=0
+Verbose=0
+branch=0
+
+command="cbuild_roms.sh $@"
+
+separator=`perl -e "print '<>' x 50;"`
+
+export MY_CPP_FLAGS=
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    -j )
+      shift
+      parallel=1
+      test=`echo $1 | grep '^[0-9]\+$'`
+      if [ "$test" != "" ]; then
+        NCPUS="-j $1"
+        shift
+      else
+        NCPUS="-j"
+      fi
+      ;;
+
+    -p )
+      shift
+      clean=0
+      dprint=1
+      debug="$1"
+      shift
+      ;;
+
+    -v )
+      shift
+      Verbose=1
+      ;;
+
+    -noclean )
+      shift
+      clean=0
+      ;;
+
+    -b )
+      shift
+      branch=1
+      branch_name=`echo $1 | grep -v '^-'`
+      if [ "$branch_name" == "" ]; then
+        echo "Please enter a ROMS GitHub branch name."
+        exit 1
+      fi
+      shift
+      ;;
+
+    * )
+      echo ""
+      echo "${separator}"
+      echo "$0 : Unknown option [ $1 ]"
+      echo ""
+      echo "Available Options:"
+      echo ""
+      echo "-j [N]          Compile in parallel using N CPUs"
+      echo "                  omit argument for all avaliable CPUs"
+      echo ""
+      echo "-b branch_name  Compile specific ROMS GitHub branch name"
+      echo "                  For example:  cbuild_roms.sh -b feature/kernel"
+      echo ""
+      echo "-p macro        Prints any Makefile macro value"
+      echo "                  For example:  cbuild_roms.sh -p FFLAGS"
+      echo ""
+      echo "-noclean        Do not clean already compiled objects"
+      echo ""
+      echo "-v              Compile in verbose mode"
+      echo "${separator}"
+      echo ""
+      exit 1
+      ;;
+  esac
+done
+
+# Set the CPP option defining the particular application. This will
+# determine the name of the ".h" header file with the application
+# CPP definitions. REQUIRED
+
+export   ROMS_APPLICATION=IRENE
+
+# Set a local environmental variable to define the path to the directories
+# where the ROMS source code is located (MY_ROOT_DIR), and this project's
+# configuration and files are kept (MY_PROJECT_DIR). Notice that if the
+# User sets the ROMS_ROOT_DIR environment variable in their computer logging
+# script describing the location from where the ROMS source code was cloned
+# or downloaded, it uses that value.
+
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
+  export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
+else
+  export      MY_ROOT_DIR=${HOME}/ocean/repository/git
+fi
+
+export     MY_PROJECT_DIR=${PWD}
+
+# The path to the user's local current ROMS source code.
+#
+# If downloading ROMS locally, this would be the user's Working Copy Path.
+# One advantage of maintaining your source code copy is that when working
+# simultaneously on multiple machines (e.g., a local workstation, a local
+# cluster, and a remote supercomputer), you can update with the latest ROMS
+# release and always get an up-to-date customized source on each machine.
+# This script allows for differing paths to the code and inputs on other
+# computers.
+
+ export       MY_ROMS_SRC=${MY_ROOT_DIR}/roms
+
+# Which type(s) of libraries would you like?
+#
+# NOTE: If you choose both and also choose to build the ROMS executable,
+#       it will be linked to the shared version of the library.
+#
+# Valid options are SHARED, STATIC, and BOTH.
+
+ export           LIBTYPE=BOTH
+
+# Do you want to build the ROMS executable?
+#
+# Valid values are: ON (build the executable) and OFF (do NOT build the
+# executable). If you comment this out the executable WILL be built.
+
+ export   ROMS_EXECUTABLE=ON
+
+# Set path of the directory containing "my_build_paths.sh".
+#
+# The user has the option to specify a customized version of this file
+# in a different directory than the one distributed with the source code,
+# ${MY_ROMS_SRC}/Compilers. If this is the case, you need to keep these
+# configurations files up-to-date.
+
+ export         COMPILERS=${MY_ROMS_SRC}/Compilers
+#export         COMPILERS=${HOME}/Compilers/ROMS
+
+#--------------------------------------------------------------------------
+# Set tunable CPP options.
+#--------------------------------------------------------------------------
+#
+# Sometimes it is desirable to activate one or more CPP options to run
+# different variants of the same application without modifying its header
+# file. If this is the case, specify each option here.
+#
+# Notice also that you need to use shell's quoting syntax to enclose the
+# definition.
+#
+#export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DAVERAGES"
+#export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DDEBUGGING"
+#
+# can be used to write time-averaged fields. Notice that you can have as
+# many definitions as you want by appending values.
+
+ bulk_flux=0                      # use WRF atmosphere boundary layer
+#bulk_flux=1                      # use ROMS bulk fluxes formulation
+
+if [ $bulk_flux -eq 1 ]; then
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DBULK_FLUXES"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DCOOL_SKIN"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DEMINUSP"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DLONGWAVE_OUT"
+fi
+
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DWIND_MINUS_CURRENT"
+
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DESMF_LIB"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DDATA_COUPLING"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DWRF_COUPLING"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DWRF_TIMEAVG"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DFRC_COUPLING"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DROMS_STDOUT"
+
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DVERIFICATION"
+
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DCOLLECT_ALLREDUCE"
+#export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DREDUCE_ALLGATHER"
+
+#export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DDEBUGGING"
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DOUT_DOUBLE"
+#export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DPOSITIVE_ZERO"
+
+#--------------------------------------------------------------------------
+# Compilation options.
+#--------------------------------------------------------------------------
+
+ export           USE_MPI=on               # distributed-memory parallelism
+ export        USE_MPIF90=on               # compile with mpif90 script
+#export         which_MPI=intel            # compile with mpiifort library
+#export         which_MPI=mpich            # compile with MPICH library
+#export         which_MPI=mpich2           # compile with MPICH2 library
+#export         which_MPI=mvapich2         # compile with MVAPICH2 library
+ export         which_MPI=openmpi          # compile with OpenMPI library
+
+ export              FORT=ifort
+#export              FORT=gfortran
+#export              FORT=pgi
+
+#export         USE_DEBUG=on               # use Fortran debugging flags
+
+# ROMS I/O choices and combinations. A more complete description of the
+# available options can be found in the wiki (https://myroms.org/wiki/IO).
+# Most users will want to enable at least USE_NETCDF4 because that will
+# instruct the ROMS build system to use nf-config to determine the
+# necessary libraries and paths to link into the ROMS executable.
+
+ export       USE_NETCDF4=on               # compile with NetCDF-4 library
+#export   USE_PARALLEL_IO=on               # Parallel I/O with NetCDF-4/HDF5
+#export           USE_PIO=on               # Parallel I/O with PIO library
+#export       USE_SCORPIO=on               # Parallel I/O with SCORPIO library
+
+# If any of the coupling component use the HDF5 Fortran API for primary
+# I/O, we need to compile the main driver with the HDF5 library.
+
+#export          USE_HDF5=on               # compile with HDF5 library
+
+#--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
+# If applicable, use my specified library paths.
+#--------------------------------------------------------------------------
+
+ export USE_MY_LIBS=no            # use system default library paths
+#export USE_MY_LIBS=yes           # use my customized library paths
+
+MY_PATHS=${COMPILERS}/my_build_paths.sh
+
+if [ "${USE_MY_LIBS}" = "yes" ]; then
+  source ${MY_PATHS} ${MY_PATHS}
+fi
+
+# Set location of the application header file.
+
+ export     MY_HEADER_DIR=${MY_PROJECT_DIR}
+
+# If you have custom analytical functions to include, enter the path here.
+
+ export MY_ANALYTICAL_DIR=${MY_PROJECT_DIR}
+
+ echo ""
+ echo "${separator}"
+
+# Put the CMake files in a project specific Build directory to avoid conflict
+# with other projects.
+
+if [ "${USE_DEBUG:-x}" = "on" ]; then
+  export        BUILD_DIR=${MY_PROJECT_DIR}/CBuild_romsG
+else
+  if [ "${USE_MPI:-x}" = "on" ]; then
+    export      BUILD_DIR=${MY_PROJECT_DIR}/CBuild_romsM
+  else
+    export      BUILD_DIR=${MY_PROJECT_DIR}/CBuild_roms
+  fi
+fi
+
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
+# If necessary, create ROMS build directory.
+
+if [ $dprint -eq 0 ]; then
+  if [ -d ${BUILD_DIR} ]; then
+    if [ $clean -eq 1 ]; then
+      echo ""
+      echo "Removing ROMS build directory: ${BUILD_DIR}"
+      echo ""
+      rm -rf ${BUILD_DIR}
+      echo ""
+      echo "Creating ROMS build directory: ${BUILD_DIR}"
+      echo ""
+      mkdir ${BUILD_DIR}
+    fi
+  else
+    if [ $clean -eq 1 ]; then
+      mkdir ${BUILD_DIR}
+      cd ${BUILD_DIR}
+    else
+      echo ""
+      echo "Option -noclean activated when the ROMS build directory did not exist"
+      echo "Creating ROMS build directory and disabling -noclean"
+      echo ""
+      clean=1
+      mkdir ${BUILD_DIR}
+      cd ${BUILD_DIR}
+    fi
+  fi
+
+  # If requested, check out requested branch from ROMS GitHub
+
+  if [ $branch -eq 1 ]; then
+    if [ ! -d ${MY_PROJECT_DIR}/src ]; then
+      echo ""
+      echo "Downloading ROMS source code from GitHub: https://www.github.com/myroms"
+      echo ""
+      git clone https://www.github.com/myroms/roms.git src
+    fi
+    echo ""
+    echo "Checking out ROMS GitHub branch: $branch_name"
+    echo ""
+    cd src
+    git checkout $branch_name
+
+    # If we are using the COMPILERS from the ROMS source code
+    # overide the value set above
+  
+    if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
+      export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
+    fi
+    export MY_ROMS_SRC=${MY_PROJECT_DIR}/src
+
+  else
+    echo ""
+    echo "Using ROMS source code from: ${MY_ROMS_SRC}"
+    echo ""
+    cd ${MY_ROMS_SRC}
+  fi
+fi
+
+#--------------------------------------------------------------------------
+# Add environmental variables constructed in 'makefile' to MY_CPP_FLAGS
+# so can be passed to ROMS.
+#--------------------------------------------------------------------------
+
+ANALYTICAL_DIR="ANALYTICAL_DIR='${MY_ANALYTICAL_DIR}'"
+HEADER=`echo ${ROMS_APPLICATION} | tr '[:upper:]' '[:lower:]'`.h
+HEADER_DIR="HEADER_DIR='${MY_HEADER_DIR}'"
+ROOT_DIR="ROOT_DIR='${MY_ROMS_SRC}'"
+
+mycppflags="${MY_CPP_FLAGS}"
+
+export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
+export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
+export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
+
+cd ${BUILD_DIR}
+
+#--------------------------------------------------------------------------
+# Configure.
+#--------------------------------------------------------------------------
+
+# Construct the "cmake" command.
+
+if [ ! -z "${LIBTYPE}" ]; then
+  ltype="-DLIBTYPE=${LIBTYPE}"
+else
+  ltype=""
+fi
+
+if [ ! -z "${FORT}" ]; then
+  if [ ${FORT} == "ifort" ]; then
+    compiler="-DCMAKE_Fortran_COMPILER=ifort"
+  elif [ ${FORT} == "gfortran" ]; then
+    compiler="-DCMAKE_Fortran_COMPILER=gfortran"
+  else
+    compiler=""
+  fi
+fi
+
+if [ ! -z "${MY_CPP_FLAGS}" ]; then
+  tmp=`echo ${MY_CPP_FLAGS} | sed 's/^ *-D//' | sed 's/ *-D/;/g'`
+  extra_flags="-DMY_CPP_FLAGS=${tmp}"
+else
+  extra_flags=""
+fi
+
+if [ ! -z "${PARPACK_LIBDIR}" ]; then
+  parpack_ldir="-DPARPACK_LIBDIR=${PARPACK_LIBDIR}"
+else
+  parpack_ldir=""
+fi
+
+if [ ! -z "${ARPACK_LIBDIR}" ]; then
+  arpack_ldir="-DARPACK_LIBDIR=${ARPACK_LIBDIR}"
+else
+  arpack_ldir=""
+fi
+
+if [ ! -z "${USE_SCORPIO}" ]; then
+  if [[ ! -z "${PIO_LIBDIR}" && ! -z "${PIO_INCDIR}" ]]; then
+    pio_ldir="-DPIO_LIBDIR=${PIO_LIBDIR}"
+    pio_idir="-DPIO_INCDIR=${PIO_INCDIR}"
+    if [[ ! -z "${PNETCDF_LIBDIR}" && ! -z "${PNETCDF_INCDIR}" ]]; then
+      pnetcdf_ldir="-DPNETCDF_LIBDIR=${PNETCDF_LIBDIR}"
+      pnetcdf_idir="-DPNETCDF_INCDIR=${PNETCDF_INCDIR}"
+    else
+      pnetcdf_ldir=""
+      pnetcdf_idir=""
+    fi
+  else
+    pio_ldir=""
+    pio_idir=""
+    pnetcdf_ldir=""
+    pnetcdf_idir=""
+  fi
+fi
+
+if [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
+  mpi="-DMPI=ON"
+else
+  mpi=""
+fi
+
+if [[ ! -z "${USE_MPIF90}" && "${USE_MPIF90}" == "on" ]]; then
+  comm="-DCOMM=${which_MPI}"
+else
+  comm=""
+fi
+
+if [ ! -z "${ROMS_EXECUTABLE}" ]; then
+  if [[ "${ROMS_EXECUTABLE}" == "ON" ]]; then
+    roms_exec="-DROMS_EXECUTABLE=ON"
+  else
+    roms_exec="-DROMS_EXECUTABLE=OFF"
+  fi
+else
+  roms_exec=""
+fi
+
+if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
+  dbg="-DCMAKE_BUILD_TYPE=Debug"
+else
+  dbg="-DCMAKE_BUILD_TYPE=Release"
+fi
+
+#--------------------------------------------------------------------------
+# Run the chosen build command.
+#--------------------------------------------------------------------------
+
+my_hdir="-DMY_HEADER_DIR=${MY_HEADER_DIR}"
+
+if [[ $dprint -eq 0 && $clean -eq 1 ]]; then
+  echo ""
+  echo "Configuring CMake for ROMS application:"
+  echo ""
+  cmake -DROMS_APP=${ROMS_APPLICATION} \
+                   ${my_hdir} \
+                   ${ltype} \
+                   ${compiler} \
+                   ${extra_flags} \
+                   ${parpack_ldir} \
+                   ${arpack_ldir} \
+                   ${pio_ldir} \
+                   ${pio_idir} \
+                   ${pnetcdf_ldir} \
+                   ${pnetcdf_idir} \
+                   ${mpi} \
+                   ${comm} \
+                   ${roms_exec} \
+                   ${dbg} \
+                   ${MY_ROMS_SRC}
+fi
+
+if [ $? -ne 0 ]; then
+  echo "cmake did not complete successfully"
+  exit 1
+fi
+
+#--------------------------------------------------------------------------
+# Compile.
+#--------------------------------------------------------------------------
+
+if [ $dprint -eq 1 ]; then
+  echo $debug:"${!debug}"
+else
+
+  echo ""
+  echo "Compiling ROMS source code:"
+  echo ""
+
+  if [ $parallel -eq 1 ]; then
+    if [ $Verbose -eq 1 ]; then
+      make VERBOSE=1 $NCPUS
+    else
+      make $NCPUS
+    fi
+  else
+    if [ $Verbose -eq 1 ]; then
+      make VERBOSE=1
+    else
+      make
+    fi
+  fi
+  make install
+
+  echo ""
+  echo "${separator}"
+  echo "CMake Build script command:    ${command}"
+  echo "ROMS source directory:         ${MY_ROMS_SRC}"
+  echo "ROMS build  directory:         ${BUILD_DIR}"
+  if [ $branch -eq 1 ]; then
+    echo "ROMS downloaded from:          https://github.com/myroms/roms.git"
+    echo "ROMS compiled branch:          $branch_name"
+  fi
+  echo "ROMS Application:              ${ROMS_APPLICATION}"
+  FFLAGS=`cat fortran_flags`
+  echo "Fortran compiler:              ${FORT}"
+  echo "Fortran flags:                ${FFLAGS}"
+  if [ -n "${mycppflags:+1}" ]; then
+    echo "Added CPP Options:            ${mycppflags}"
+  fi
+  echo "${separator}"
+  echo ""
+fi
+
+cd ${MY_PROJECT_DIR}
+
+# If ROMS_EXECUTABLE is set to OFF remove the symlink from
+# previous builds if present.
+
+if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
+  if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
+    if [ -L romsG ]; then
+      rm -f romsG
+    fi
+  elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
+    if [ -L romsM ]; then
+      rm -f romsM
+    fi
+  else
+    if [ -L romsS ]; then
+      rm -f romsS
+    fi
+  fi
+fi
+
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# RPATH/RUNPATH are set correctly for both the build tree and
+# installed locations of the ROMS executable.
+
+if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
+  if [ $dprint -eq 0 ]; then
+    if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
+      cp -pfv ${BUILD_DIR}/romsG .
+    elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
+      cp -pfv ${BUILD_DIR}/romsM .
+    else
+      cp -pfv ${BUILD_DIR}/romsS .
+    fi
+  fi
+fi

--- a/IRENE/Forward/build_roms.csh
+++ b/IRENE/Forward/build_roms.csh
@@ -274,8 +274,8 @@ endif
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-#setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF.4.3
- setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+#setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF4.3
+ setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 # Decode WRF version from its README file to decide the appropriate data
 # file links needed.

--- a/IRENE/Forward/build_roms.csh
+++ b/IRENE/Forward/build_roms.csh
@@ -352,6 +352,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/IRENE/Forward/build_roms.csh
+++ b/IRENE/Forward/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      IRENE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -432,7 +432,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/IRENE/Forward/build_roms.sh
+++ b/IRENE/Forward/build_roms.sh
@@ -350,6 +350,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/IRENE/Forward/build_roms.sh
+++ b/IRENE/Forward/build_roms.sh
@@ -275,7 +275,7 @@ fi
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-#export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF.4.3
+#export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF.git/4.3
  export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then

--- a/IRENE/Forward/build_roms.sh
+++ b/IRENE/Forward/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=IRENE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -430,7 +430,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/IRENE/Forward/cbuild_roms.csh
+++ b/IRENE/Forward/cbuild_roms.csh
@@ -397,29 +397,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -627,9 +605,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -637,27 +615,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/IRENE/Forward/cbuild_roms.csh
+++ b/IRENE/Forward/cbuild_roms.csh
@@ -364,10 +364,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -568,7 +568,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/IRENE/Forward/cbuild_roms.csh
+++ b/IRENE/Forward/cbuild_roms.csh
@@ -273,6 +273,34 @@ endif
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/IRENE/Forward/cbuild_roms.csh
+++ b/IRENE/Forward/cbuild_roms.csh
@@ -321,6 +321,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/IRENE/Forward/cbuild_roms.sh
+++ b/IRENE/Forward/cbuild_roms.sh
@@ -271,6 +271,34 @@ fi
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/IRENE/Forward/cbuild_roms.sh
+++ b/IRENE/Forward/cbuild_roms.sh
@@ -383,29 +383,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -596,20 +574,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/IRENE/Forward/cbuild_roms.sh
+++ b/IRENE/Forward/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=IRENE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -353,7 +353,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -543,7 +543,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/IRENE/Forward/cbuild_roms.sh
+++ b/IRENE/Forward/cbuild_roms.sh
@@ -307,6 +307,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/ARRAY_MODES/build_roms.csh
+++ b/WC13/ARRAY_MODES/build_roms.csh
@@ -266,7 +266,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/ARRAY_MODES/build_roms.csh
+++ b/WC13/ARRAY_MODES/build_roms.csh
@@ -340,6 +340,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/ARRAY_MODES/build_roms.csh
+++ b/WC13/ARRAY_MODES/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -420,7 +420,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/ARRAY_MODES/build_roms.sh
+++ b/WC13/ARRAY_MODES/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/ARRAY_MODES/build_roms.sh
+++ b/WC13/ARRAY_MODES/build_roms.sh
@@ -267,7 +267,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/ARRAY_MODES/build_roms.sh
+++ b/WC13/ARRAY_MODES/build_roms.sh
@@ -341,6 +341,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/ARRAY_MODES/cbuild_roms.csh
+++ b/WC13/ARRAY_MODES/cbuild_roms.csh
@@ -264,6 +264,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/ARRAY_MODES/cbuild_roms.csh
+++ b/WC13/ARRAY_MODES/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/ARRAY_MODES/cbuild_roms.csh
+++ b/WC13/ARRAY_MODES/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/ARRAY_MODES/cbuild_roms.csh
+++ b/WC13/ARRAY_MODES/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/ARRAY_MODES/cbuild_roms.sh
+++ b/WC13/ARRAY_MODES/cbuild_roms.sh
@@ -374,29 +374,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -587,20 +565,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/ARRAY_MODES/cbuild_roms.sh
+++ b/WC13/ARRAY_MODES/cbuild_roms.sh
@@ -262,6 +262,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/ARRAY_MODES/cbuild_roms.sh
+++ b/WC13/ARRAY_MODES/cbuild_roms.sh
@@ -298,6 +298,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/ARRAY_MODES/cbuild_roms.sh
+++ b/WC13/ARRAY_MODES/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -344,7 +344,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -534,7 +534,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/I4DVAR/build_roms.csh
+++ b/WC13/I4DVAR/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/I4DVAR/build_roms.csh
+++ b/WC13/I4DVAR/build_roms.csh
@@ -341,6 +341,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/I4DVAR/build_roms.csh
+++ b/WC13/I4DVAR/build_roms.csh
@@ -267,7 +267,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/I4DVAR/build_roms.sh
+++ b/WC13/I4DVAR/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -422,7 +422,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/I4DVAR/build_roms.sh
+++ b/WC13/I4DVAR/build_roms.sh
@@ -342,6 +342,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/I4DVAR/build_roms.sh
+++ b/WC13/I4DVAR/build_roms.sh
@@ -268,7 +268,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/I4DVAR/cbuild_roms.csh
+++ b/WC13/I4DVAR/cbuild_roms.csh
@@ -260,6 +260,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/I4DVAR/cbuild_roms.csh
+++ b/WC13/I4DVAR/cbuild_roms.csh
@@ -308,6 +308,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/I4DVAR/cbuild_roms.csh
+++ b/WC13/I4DVAR/cbuild_roms.csh
@@ -351,10 +351,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -555,7 +555,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/I4DVAR/cbuild_roms.csh
+++ b/WC13/I4DVAR/cbuild_roms.csh
@@ -384,29 +384,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -614,9 +592,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -624,27 +602,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/I4DVAR/cbuild_roms.sh
+++ b/WC13/I4DVAR/cbuild_roms.sh
@@ -294,6 +294,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/I4DVAR/cbuild_roms.sh
+++ b/WC13/I4DVAR/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -340,7 +340,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -530,7 +530,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/I4DVAR/cbuild_roms.sh
+++ b/WC13/I4DVAR/cbuild_roms.sh
@@ -370,29 +370,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -583,20 +561,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/I4DVAR/cbuild_roms.sh
+++ b/WC13/I4DVAR/cbuild_roms.sh
@@ -258,6 +258,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/I4DVAR_analysis_impact/build_roms.csh
+++ b/WC13/I4DVAR_analysis_impact/build_roms.csh
@@ -266,7 +266,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/I4DVAR_analysis_impact/build_roms.csh
+++ b/WC13/I4DVAR_analysis_impact/build_roms.csh
@@ -340,6 +340,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/I4DVAR_analysis_impact/build_roms.csh
+++ b/WC13/I4DVAR_analysis_impact/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -420,7 +420,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/I4DVAR_analysis_impact/build_roms.sh
+++ b/WC13/I4DVAR_analysis_impact/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/I4DVAR_analysis_impact/build_roms.sh
+++ b/WC13/I4DVAR_analysis_impact/build_roms.sh
@@ -267,7 +267,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/I4DVAR_analysis_impact/build_roms.sh
+++ b/WC13/I4DVAR_analysis_impact/build_roms.sh
@@ -341,6 +341,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/I4DVAR_analysis_impact/cbuild_roms.csh
+++ b/WC13/I4DVAR_analysis_impact/cbuild_roms.csh
@@ -264,6 +264,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/I4DVAR_analysis_impact/cbuild_roms.csh
+++ b/WC13/I4DVAR_analysis_impact/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/I4DVAR_analysis_impact/cbuild_roms.csh
+++ b/WC13/I4DVAR_analysis_impact/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/I4DVAR_analysis_impact/cbuild_roms.csh
+++ b/WC13/I4DVAR_analysis_impact/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/I4DVAR_analysis_impact/cbuild_roms.sh
+++ b/WC13/I4DVAR_analysis_impact/cbuild_roms.sh
@@ -374,29 +374,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -587,20 +565,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/I4DVAR_analysis_impact/cbuild_roms.sh
+++ b/WC13/I4DVAR_analysis_impact/cbuild_roms.sh
@@ -262,6 +262,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/I4DVAR_analysis_impact/cbuild_roms.sh
+++ b/WC13/I4DVAR_analysis_impact/cbuild_roms.sh
@@ -298,6 +298,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/I4DVAR_analysis_impact/cbuild_roms.sh
+++ b/WC13/I4DVAR_analysis_impact/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -344,7 +344,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -534,7 +534,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/I4DVAR_split/build_roms.csh
+++ b/WC13/I4DVAR_split/build_roms.csh
@@ -271,7 +271,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/I4DVAR_split/build_roms.csh
+++ b/WC13/I4DVAR_split/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -425,7 +425,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/I4DVAR_split/build_roms.csh
+++ b/WC13/I4DVAR_split/build_roms.csh
@@ -345,6 +345,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/I4DVAR_split/build_roms.sh
+++ b/WC13/I4DVAR_split/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -429,7 +429,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/I4DVAR_split/build_roms.sh
+++ b/WC13/I4DVAR_split/build_roms.sh
@@ -349,6 +349,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/I4DVAR_split/build_roms.sh
+++ b/WC13/I4DVAR_split/build_roms.sh
@@ -275,7 +275,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/I4DVAR_split/cbuild_roms.csh
+++ b/WC13/I4DVAR_split/cbuild_roms.csh
@@ -317,6 +317,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/I4DVAR_split/cbuild_roms.csh
+++ b/WC13/I4DVAR_split/cbuild_roms.csh
@@ -393,29 +393,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -623,9 +601,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -633,27 +611,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/I4DVAR_split/cbuild_roms.csh
+++ b/WC13/I4DVAR_split/cbuild_roms.csh
@@ -269,6 +269,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/I4DVAR_split/cbuild_roms.csh
+++ b/WC13/I4DVAR_split/cbuild_roms.csh
@@ -360,10 +360,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -564,7 +564,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/I4DVAR_split/cbuild_roms.sh
+++ b/WC13/I4DVAR_split/cbuild_roms.sh
@@ -382,29 +382,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -595,20 +573,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/I4DVAR_split/cbuild_roms.sh
+++ b/WC13/I4DVAR_split/cbuild_roms.sh
@@ -270,6 +270,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/I4DVAR_split/cbuild_roms.sh
+++ b/WC13/I4DVAR_split/cbuild_roms.sh
@@ -306,6 +306,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/I4DVAR_split/cbuild_roms.sh
+++ b/WC13/I4DVAR_split/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -352,7 +352,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -542,7 +542,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/Normalization/build_roms.csh
+++ b/WC13/Normalization/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -423,7 +423,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/Normalization/build_roms.csh
+++ b/WC13/Normalization/build_roms.csh
@@ -269,7 +269,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/Normalization/build_roms.csh
+++ b/WC13/Normalization/build_roms.csh
@@ -343,6 +343,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/Normalization/build_roms.sh
+++ b/WC13/Normalization/build_roms.sh
@@ -270,7 +270,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/Normalization/build_roms.sh
+++ b/WC13/Normalization/build_roms.sh
@@ -344,6 +344,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/Normalization/build_roms.sh
+++ b/WC13/Normalization/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/Normalization/cbuild_roms.csh
+++ b/WC13/Normalization/cbuild_roms.csh
@@ -267,6 +267,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/Normalization/cbuild_roms.csh
+++ b/WC13/Normalization/cbuild_roms.csh
@@ -391,29 +391,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -621,9 +599,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -631,27 +609,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/Normalization/cbuild_roms.csh
+++ b/WC13/Normalization/cbuild_roms.csh
@@ -315,6 +315,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/Normalization/cbuild_roms.csh
+++ b/WC13/Normalization/cbuild_roms.csh
@@ -358,10 +358,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -562,7 +562,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/Normalization/cbuild_roms.sh
+++ b/WC13/Normalization/cbuild_roms.sh
@@ -377,29 +377,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -590,20 +568,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/Normalization/cbuild_roms.sh
+++ b/WC13/Normalization/cbuild_roms.sh
@@ -265,6 +265,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/Normalization/cbuild_roms.sh
+++ b/WC13/Normalization/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -347,7 +347,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -537,7 +537,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/Normalization/cbuild_roms.sh
+++ b/WC13/Normalization/cbuild_roms.sh
@@ -301,6 +301,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.csh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -429,7 +429,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.csh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.csh
@@ -348,6 +348,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.csh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.csh
@@ -274,7 +274,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.sh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR} src
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -430,7 +430,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.sh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.sh
@@ -349,6 +349,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.sh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/build_roms.sh
@@ -275,7 +275,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.csh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.csh
@@ -267,6 +267,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.csh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.csh
@@ -391,29 +391,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -621,9 +599,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -631,27 +609,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.csh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.csh
@@ -315,6 +315,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.csh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.csh
@@ -358,10 +358,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -562,7 +562,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.sh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.sh
@@ -377,29 +377,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -590,20 +568,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.sh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.sh
@@ -265,6 +265,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.sh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -347,7 +347,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -537,7 +537,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.sh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/cbuild_roms.sh
@@ -301,6 +301,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR/build_roms.csh
+++ b/WC13/RBL4DVAR/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -428,7 +428,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR/build_roms.csh
+++ b/WC13/RBL4DVAR/build_roms.csh
@@ -348,6 +348,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR/build_roms.csh
+++ b/WC13/RBL4DVAR/build_roms.csh
@@ -274,7 +274,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR/build_roms.sh
+++ b/WC13/RBL4DVAR/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -429,7 +429,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR/build_roms.sh
+++ b/WC13/RBL4DVAR/build_roms.sh
@@ -349,6 +349,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR/build_roms.sh
+++ b/WC13/RBL4DVAR/build_roms.sh
@@ -275,7 +275,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR/cbuild_roms.csh
+++ b/WC13/RBL4DVAR/cbuild_roms.csh
@@ -267,6 +267,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR/cbuild_roms.csh
+++ b/WC13/RBL4DVAR/cbuild_roms.csh
@@ -391,29 +391,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -621,9 +599,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -631,27 +609,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR/cbuild_roms.csh
+++ b/WC13/RBL4DVAR/cbuild_roms.csh
@@ -315,6 +315,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR/cbuild_roms.csh
+++ b/WC13/RBL4DVAR/cbuild_roms.csh
@@ -358,10 +358,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -562,7 +562,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR/cbuild_roms.sh
+++ b/WC13/RBL4DVAR/cbuild_roms.sh
@@ -377,29 +377,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -590,20 +568,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR/cbuild_roms.sh
+++ b/WC13/RBL4DVAR/cbuild_roms.sh
@@ -265,6 +265,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR/cbuild_roms.sh
+++ b/WC13/RBL4DVAR/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -347,7 +347,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -537,7 +537,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR/cbuild_roms.sh
+++ b/WC13/RBL4DVAR/cbuild_roms.sh
@@ -301,6 +301,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_analysis_impact/build_roms.csh
+++ b/WC13/RBL4DVAR_analysis_impact/build_roms.csh
@@ -270,7 +270,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_analysis_impact/build_roms.csh
+++ b/WC13/RBL4DVAR_analysis_impact/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_analysis_impact/build_roms.csh
+++ b/WC13/RBL4DVAR_analysis_impact/build_roms.csh
@@ -344,6 +344,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_analysis_impact/build_roms.sh
+++ b/WC13/RBL4DVAR_analysis_impact/build_roms.sh
@@ -271,7 +271,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_analysis_impact/build_roms.sh
+++ b/WC13/RBL4DVAR_analysis_impact/build_roms.sh
@@ -345,6 +345,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_analysis_impact/build_roms.sh
+++ b/WC13/RBL4DVAR_analysis_impact/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -425,7 +425,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_analysis_impact/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_analysis_impact/cbuild_roms.csh
@@ -388,35 +388,11 @@ set ROOT_DIR = "ROOT_DIR='${MY_ROMS_SRC}'"
 
 set mycppflags = "${MY_CPP_FLAGS}"
 
-set mycppflags = "${MY_CPP_FLAGS}"
-
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -624,9 +600,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -634,27 +610,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_analysis_impact/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_analysis_impact/cbuild_roms.csh
@@ -316,6 +316,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_analysis_impact/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_analysis_impact/cbuild_roms.csh
@@ -359,10 +359,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -563,7 +563,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_analysis_impact/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_analysis_impact/cbuild_roms.csh
@@ -268,6 +268,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_analysis_impact/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_analysis_impact/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -348,7 +348,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -538,7 +538,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_analysis_impact/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_analysis_impact/cbuild_roms.sh
@@ -302,6 +302,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_analysis_impact/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_analysis_impact/cbuild_roms.sh
@@ -266,6 +266,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_analysis_impact/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_analysis_impact/cbuild_roms.sh
@@ -378,29 +378,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -591,20 +569,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_analysis_sensitivity/build_roms.csh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/build_roms.csh
@@ -266,7 +266,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_analysis_sensitivity/build_roms.csh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/build_roms.csh
@@ -340,6 +340,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_analysis_sensitivity/build_roms.csh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -420,7 +420,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_analysis_sensitivity/build_roms.sh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_analysis_sensitivity/build_roms.sh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/build_roms.sh
@@ -267,7 +267,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_analysis_sensitivity/build_roms.sh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/build_roms.sh
@@ -341,6 +341,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.csh
@@ -264,6 +264,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.sh
@@ -374,29 +374,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -587,20 +565,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.sh
@@ -262,6 +262,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.sh
@@ -298,6 +298,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -225,7 +225,7 @@ export     MY_PROJECT_DIR=${PWD}
 #export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DREDUCE_ALLGATHER"
 
 #export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DDEBUGGING"
-#export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DPOSITIVE_ZERO" 
+#export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DPOSITIVE_ZERO"
 
 #--------------------------------------------------------------------------
 # Compilation options.
@@ -344,7 +344,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -534,7 +534,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.csh
@@ -340,6 +340,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -420,7 +420,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.csh
@@ -264,7 +264,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.sh
@@ -265,7 +265,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/build_roms.sh
@@ -341,6 +341,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.csh
@@ -262,6 +262,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.sh
@@ -374,29 +374,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -587,20 +565,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.sh
@@ -260,6 +260,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.sh
@@ -298,6 +298,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -344,7 +344,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -534,7 +534,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.csh
@@ -341,6 +341,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.csh
@@ -265,7 +265,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.sh
@@ -266,7 +266,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -422,7 +422,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/build_roms.sh
@@ -342,6 +342,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.csh
@@ -263,6 +263,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.csh
@@ -389,29 +389,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -619,9 +597,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -629,27 +607,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.csh
@@ -356,10 +356,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -560,7 +560,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.csh
@@ -313,6 +313,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.sh
@@ -261,6 +261,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.sh
@@ -299,6 +299,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -345,7 +345,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -535,7 +535,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/cbuild_roms.sh
@@ -375,29 +375,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -588,20 +566,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.csh
@@ -340,6 +340,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -420,7 +420,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.csh
@@ -264,7 +264,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.sh
@@ -265,7 +265,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/build_roms.sh
@@ -341,6 +341,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.csh
@@ -262,6 +262,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.sh
@@ -374,29 +374,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -587,20 +565,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.sh
@@ -260,6 +260,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.sh
@@ -298,6 +298,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -344,7 +344,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -534,7 +534,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_forecast_impact/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/build_roms.csh
@@ -341,6 +341,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_forecast_impact/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/build_roms.csh
@@ -267,7 +267,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_impact/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/build_roms.sh
@@ -268,7 +268,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_impact/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/build_roms.sh
@@ -344,6 +344,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_forecast_impact/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/cbuild_roms.csh
@@ -389,29 +389,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -619,9 +597,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -629,27 +607,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_forecast_impact/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/cbuild_roms.csh
@@ -265,6 +265,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_impact/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/cbuild_roms.csh
@@ -356,10 +356,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -560,7 +560,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_forecast_impact/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_impact/cbuild_roms.csh
@@ -313,6 +313,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_forecast_impact/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/cbuild_roms.sh
@@ -299,6 +299,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_forecast_impact/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/cbuild_roms.sh
@@ -263,6 +263,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_impact/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -345,7 +345,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -535,7 +535,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_impact/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_impact/cbuild_roms.sh
@@ -375,29 +375,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -588,20 +566,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -423,7 +423,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.csh
@@ -343,6 +343,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.csh
@@ -267,7 +267,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.sh
@@ -265,7 +265,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/build_roms.sh
@@ -341,6 +341,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.csh
@@ -262,6 +262,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.sh
@@ -374,29 +374,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -587,20 +565,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.sh
@@ -260,6 +260,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.sh
@@ -298,6 +298,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -344,7 +344,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -534,7 +534,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.csh
@@ -341,6 +341,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.csh
@@ -265,7 +265,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -422,7 +422,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.sh
@@ -266,7 +266,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/build_roms.sh
@@ -342,6 +342,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.csh
@@ -263,6 +263,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.csh
@@ -389,29 +389,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -619,9 +597,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -629,27 +607,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.csh
@@ -356,10 +356,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -560,7 +560,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.csh
@@ -313,6 +313,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.sh
@@ -261,6 +261,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.sh
@@ -299,6 +299,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -345,7 +345,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -535,7 +535,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/cbuild_roms.sh
@@ -375,29 +375,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -588,20 +566,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.csh
@@ -340,6 +340,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -420,7 +420,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.csh
@@ -264,7 +264,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.sh
@@ -265,7 +265,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/build_roms.sh
@@ -341,6 +341,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.csh
@@ -262,6 +262,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.sh
@@ -374,29 +374,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -587,20 +565,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.sh
@@ -260,6 +260,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.sh
@@ -298,6 +298,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -344,7 +344,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -534,7 +534,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/build_roms.csh
@@ -341,6 +341,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/build_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/build_roms.csh
@@ -267,7 +267,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_sensitivity/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/build_roms.sh
@@ -268,7 +268,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_forecast_sensitivity/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/build_roms.sh
@@ -344,6 +344,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/build_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.csh
@@ -389,29 +389,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -619,9 +597,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -629,27 +607,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.csh
@@ -265,6 +265,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.csh
@@ -356,10 +356,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -560,7 +560,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.csh
@@ -313,6 +313,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.sh
@@ -299,6 +299,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.sh
@@ -263,6 +263,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -345,7 +345,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -535,7 +535,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/cbuild_roms.sh
@@ -375,29 +375,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -588,20 +566,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_split/build_roms.csh
+++ b/WC13/RBL4DVAR_split/build_roms.csh
@@ -350,6 +350,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/WC13/RBL4DVAR_split/build_roms.csh
+++ b/WC13/RBL4DVAR_split/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -430,7 +430,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/WC13/RBL4DVAR_split/build_roms.csh
+++ b/WC13/RBL4DVAR_split/build_roms.csh
@@ -276,7 +276,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_split/build_roms.sh
+++ b/WC13/RBL4DVAR_split/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -432,7 +432,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/WC13/RBL4DVAR_split/build_roms.sh
+++ b/WC13/RBL4DVAR_split/build_roms.sh
@@ -352,6 +352,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/WC13/RBL4DVAR_split/build_roms.sh
+++ b/WC13/RBL4DVAR_split/build_roms.sh
@@ -278,7 +278,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/WC13/RBL4DVAR_split/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_split/cbuild_roms.csh
@@ -365,10 +365,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -569,7 +569,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/WC13/RBL4DVAR_split/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_split/cbuild_roms.csh
@@ -322,6 +322,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/WC13/RBL4DVAR_split/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_split/cbuild_roms.csh
@@ -274,6 +274,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_split/cbuild_roms.csh
+++ b/WC13/RBL4DVAR_split/cbuild_roms.csh
@@ -398,29 +398,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -628,9 +606,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -638,27 +616,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/WC13/RBL4DVAR_split/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_split/cbuild_roms.sh
@@ -385,29 +385,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -598,20 +576,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/WC13/RBL4DVAR_split/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_split/cbuild_roms.sh
@@ -273,6 +273,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/WC13/RBL4DVAR_split/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_split/cbuild_roms.sh
@@ -309,6 +309,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/WC13/RBL4DVAR_split/cbuild_roms.sh
+++ b/WC13/RBL4DVAR_split/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WC13
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -355,7 +355,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -545,7 +545,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/basin/build_roms.csh
+++ b/basin/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      BASIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/basin/build_roms.csh
+++ b/basin/build_roms.csh
@@ -270,7 +270,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/basin/build_roms.csh
+++ b/basin/build_roms.csh
@@ -344,6 +344,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/basin/build_roms.sh
+++ b/basin/build_roms.sh
@@ -271,7 +271,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/basin/build_roms.sh
+++ b/basin/build_roms.sh
@@ -345,6 +345,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/basin/build_roms.sh
+++ b/basin/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=BASIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -425,7 +425,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/basin/cbuild_roms.csh
+++ b/basin/cbuild_roms.csh
@@ -392,29 +392,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -622,9 +600,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -632,27 +610,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/basin/cbuild_roms.csh
+++ b/basin/cbuild_roms.csh
@@ -316,6 +316,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/basin/cbuild_roms.csh
+++ b/basin/cbuild_roms.csh
@@ -359,10 +359,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -563,7 +563,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/basin/cbuild_roms.csh
+++ b/basin/cbuild_roms.csh
@@ -268,6 +268,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/basin/cbuild_roms.sh
+++ b/basin/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=BASIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -348,7 +348,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -538,7 +538,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/basin/cbuild_roms.sh
+++ b/basin/cbuild_roms.sh
@@ -302,6 +302,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/basin/cbuild_roms.sh
+++ b/basin/cbuild_roms.sh
@@ -266,6 +266,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/basin/cbuild_roms.sh
+++ b/basin/cbuild_roms.sh
@@ -378,29 +378,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -591,20 +569,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/benchmark/build_roms.csh
+++ b/benchmark/build_roms.csh
@@ -263,7 +263,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/benchmark/build_roms.csh
+++ b/benchmark/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION     BENCHMARK
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -417,7 +417,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/benchmark/build_roms.csh
+++ b/benchmark/build_roms.csh
@@ -337,6 +337,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/benchmark/build_roms.sh
+++ b/benchmark/build_roms.sh
@@ -338,6 +338,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/benchmark/build_roms.sh
+++ b/benchmark/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=BENCHMARK
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -418,7 +418,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/benchmark/build_roms.sh
+++ b/benchmark/build_roms.sh
@@ -264,7 +264,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/benchmark/cbuild_roms.csh
+++ b/benchmark/cbuild_roms.csh
@@ -352,10 +352,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -556,7 +556,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/benchmark/cbuild_roms.csh
+++ b/benchmark/cbuild_roms.csh
@@ -309,6 +309,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/benchmark/cbuild_roms.csh
+++ b/benchmark/cbuild_roms.csh
@@ -261,6 +261,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/benchmark/cbuild_roms.csh
+++ b/benchmark/cbuild_roms.csh
@@ -385,29 +385,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -615,9 +593,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -625,27 +603,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/benchmark/cbuild_roms.sh
+++ b/benchmark/cbuild_roms.sh
@@ -295,6 +295,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/benchmark/cbuild_roms.sh
+++ b/benchmark/cbuild_roms.sh
@@ -371,29 +371,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -584,20 +562,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/benchmark/cbuild_roms.sh
+++ b/benchmark/cbuild_roms.sh
@@ -259,6 +259,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/benchmark/cbuild_roms.sh
+++ b/benchmark/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=BENCHMARK
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -341,7 +341,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -531,7 +531,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/bio_toy/build_roms.csh
+++ b/bio_toy/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      BIO_TOY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -419,7 +419,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/bio_toy/build_roms.csh
+++ b/bio_toy/build_roms.csh
@@ -338,6 +338,20 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
+# If necessary, create ROMS build directory.
+
+if ( ! -d $BUILD_DIR ) then
+  echo ""
+  echo "Creating ROMS build directory: ${BUILD_DIR}"
+  echo ""
+  mkdir $BUILD_DIR
+endif
+
 # Go to the users source directory to compile. The options set above will
 # pick up the application-specific code from the appropriate place.
 

--- a/bio_toy/build_roms.csh
+++ b/bio_toy/build_roms.csh
@@ -264,7 +264,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/bio_toy/build_roms.sh
+++ b/bio_toy/build_roms.sh
@@ -339,6 +339,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/bio_toy/build_roms.sh
+++ b/bio_toy/build_roms.sh
@@ -265,7 +265,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/bio_toy/build_roms.sh
+++ b/bio_toy/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=BIO_TOY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -419,7 +419,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/bio_toy/cbuild_roms.csh
+++ b/bio_toy/cbuild_roms.csh
@@ -262,6 +262,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/bio_toy/cbuild_roms.csh
+++ b/bio_toy/cbuild_roms.csh
@@ -386,29 +386,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -616,9 +594,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -626,27 +604,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/bio_toy/cbuild_roms.csh
+++ b/bio_toy/cbuild_roms.csh
@@ -353,10 +353,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -557,7 +557,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/bio_toy/cbuild_roms.csh
+++ b/bio_toy/cbuild_roms.csh
@@ -310,6 +310,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/bio_toy/cbuild_roms.sh
+++ b/bio_toy/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=BIO_TOY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -342,7 +342,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -532,7 +532,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/bio_toy/cbuild_roms.sh
+++ b/bio_toy/cbuild_roms.sh
@@ -296,6 +296,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/bio_toy/cbuild_roms.sh
+++ b/bio_toy/cbuild_roms.sh
@@ -260,6 +260,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/bio_toy/cbuild_roms.sh
+++ b/bio_toy/cbuild_roms.sh
@@ -372,29 +372,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -585,20 +563,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/bl_test/build_roms.csh
+++ b/bl_test/build_roms.csh
@@ -341,6 +341,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/bl_test/build_roms.csh
+++ b/bl_test/build_roms.csh
@@ -138,7 +138,7 @@ end
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/bl_test/build_roms.csh
+++ b/bl_test/build_roms.csh
@@ -267,7 +267,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/bl_test/build_roms.sh
+++ b/bl_test/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=BL_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -422,7 +422,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/bl_test/build_roms.sh
+++ b/bl_test/build_roms.sh
@@ -342,6 +342,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/bl_test/build_roms.sh
+++ b/bl_test/build_roms.sh
@@ -268,7 +268,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/bl_test/cbuild_roms.csh
+++ b/bl_test/cbuild_roms.csh
@@ -389,29 +389,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -619,9 +597,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -629,27 +607,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/bl_test/cbuild_roms.csh
+++ b/bl_test/cbuild_roms.csh
@@ -265,6 +265,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/bl_test/cbuild_roms.csh
+++ b/bl_test/cbuild_roms.csh
@@ -356,10 +356,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -560,7 +560,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/bl_test/cbuild_roms.csh
+++ b/bl_test/cbuild_roms.csh
@@ -313,6 +313,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/bl_test/cbuild_roms.sh
+++ b/bl_test/cbuild_roms.sh
@@ -299,6 +299,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/bl_test/cbuild_roms.sh
+++ b/bl_test/cbuild_roms.sh
@@ -263,6 +263,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/bl_test/cbuild_roms.sh
+++ b/bl_test/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=BL_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -345,7 +345,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -535,7 +535,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/bl_test/cbuild_roms.sh
+++ b/bl_test/cbuild_roms.sh
@@ -375,29 +375,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -588,20 +566,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/canyon/build_roms.csh
+++ b/canyon/build_roms.csh
@@ -333,6 +333,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/canyon/build_roms.csh
+++ b/canyon/build_roms.csh
@@ -138,7 +138,7 @@ end
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -413,7 +413,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/canyon/build_roms.csh
+++ b/canyon/build_roms.csh
@@ -259,7 +259,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/canyon/build_roms.sh
+++ b/canyon/build_roms.sh
@@ -260,7 +260,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/canyon/build_roms.sh
+++ b/canyon/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=CANYON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -414,7 +414,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/canyon/build_roms.sh
+++ b/canyon/build_roms.sh
@@ -334,6 +334,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/canyon/cbuild_roms.csh
+++ b/canyon/cbuild_roms.csh
@@ -348,10 +348,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -552,7 +552,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/canyon/cbuild_roms.csh
+++ b/canyon/cbuild_roms.csh
@@ -381,29 +381,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -611,9 +589,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -621,27 +599,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/canyon/cbuild_roms.csh
+++ b/canyon/cbuild_roms.csh
@@ -305,6 +305,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/canyon/cbuild_roms.csh
+++ b/canyon/cbuild_roms.csh
@@ -257,6 +257,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/canyon/cbuild_roms.sh
+++ b/canyon/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=CANYON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -337,7 +337,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -527,7 +527,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/canyon/cbuild_roms.sh
+++ b/canyon/cbuild_roms.sh
@@ -255,6 +255,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/canyon/cbuild_roms.sh
+++ b/canyon/cbuild_roms.sh
@@ -367,29 +367,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -580,20 +558,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/canyon/cbuild_roms.sh
+++ b/canyon/cbuild_roms.sh
@@ -291,6 +291,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/channel/Forward/build_roms.csh
+++ b/channel/Forward/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      CHANNEL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -417,7 +417,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/channel/Forward/build_roms.csh
+++ b/channel/Forward/build_roms.csh
@@ -263,7 +263,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/channel/Forward/build_roms.csh
+++ b/channel/Forward/build_roms.csh
@@ -337,6 +337,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/channel/Forward/build_roms.sh
+++ b/channel/Forward/build_roms.sh
@@ -338,6 +338,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/channel/Forward/build_roms.sh
+++ b/channel/Forward/build_roms.sh
@@ -264,7 +264,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/channel/Forward/build_roms.sh
+++ b/channel/Forward/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=CHANNEL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -418,7 +418,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/channel/Forward/cbuild_roms.csh
+++ b/channel/Forward/cbuild_roms.csh
@@ -352,10 +352,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -556,7 +556,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/channel/Forward/cbuild_roms.csh
+++ b/channel/Forward/cbuild_roms.csh
@@ -309,6 +309,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/channel/Forward/cbuild_roms.csh
+++ b/channel/Forward/cbuild_roms.csh
@@ -261,6 +261,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/channel/Forward/cbuild_roms.csh
+++ b/channel/Forward/cbuild_roms.csh
@@ -385,29 +385,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -615,9 +593,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -625,27 +603,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/channel/Forward/cbuild_roms.sh
+++ b/channel/Forward/cbuild_roms.sh
@@ -295,6 +295,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/channel/Forward/cbuild_roms.sh
+++ b/channel/Forward/cbuild_roms.sh
@@ -371,29 +371,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -584,20 +562,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/channel/Forward/cbuild_roms.sh
+++ b/channel/Forward/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=CHANNEL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -341,7 +341,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -531,7 +531,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/channel/Forward/cbuild_roms.sh
+++ b/channel/Forward/cbuild_roms.sh
@@ -259,6 +259,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/channel/OP/build_roms.csh
+++ b/channel/OP/build_roms.csh
@@ -338,6 +338,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/channel/OP/build_roms.csh
+++ b/channel/OP/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      CHANNEL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -418,7 +418,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/channel/OP/build_roms.csh
+++ b/channel/OP/build_roms.csh
@@ -264,7 +264,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/channel/OP/build_roms.sh
+++ b/channel/OP/build_roms.sh
@@ -339,6 +339,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/channel/OP/build_roms.sh
+++ b/channel/OP/build_roms.sh
@@ -265,7 +265,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/channel/OP/build_roms.sh
+++ b/channel/OP/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=CHANNEL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -419,7 +419,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/channel/OP/cbuild_roms.csh
+++ b/channel/OP/cbuild_roms.csh
@@ -262,6 +262,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/channel/OP/cbuild_roms.csh
+++ b/channel/OP/cbuild_roms.csh
@@ -386,29 +386,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -616,9 +594,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -626,27 +604,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/channel/OP/cbuild_roms.csh
+++ b/channel/OP/cbuild_roms.csh
@@ -353,10 +353,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -557,7 +557,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/channel/OP/cbuild_roms.csh
+++ b/channel/OP/cbuild_roms.csh
@@ -310,6 +310,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/channel/OP/cbuild_roms.sh
+++ b/channel/OP/cbuild_roms.sh
@@ -296,6 +296,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/channel/OP/cbuild_roms.sh
+++ b/channel/OP/cbuild_roms.sh
@@ -260,6 +260,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/channel/OP/cbuild_roms.sh
+++ b/channel/OP/cbuild_roms.sh
@@ -372,29 +372,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -585,20 +563,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/channel/OP/cbuild_roms.sh
+++ b/channel/OP/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=CHANNEL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -342,7 +342,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -532,7 +532,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# **ROMS Test Cases**
+# ROMS Test Cases
 
 ![roms_test](https://github.com/myroms/roms_test/assets/23062912/faf56433-3e95-469f-a65c-8464d9c690b2)
 
-# **License**
+# License
 
 **Copyright (c) 2002-2023 The ROMS/TOMS Group**
 

--- a/dogbone/Composite/build_roms.csh
+++ b/dogbone/Composite/build_roms.csh
@@ -269,7 +269,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/dogbone/Composite/build_roms.csh
+++ b/dogbone/Composite/build_roms.csh
@@ -343,6 +343,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/dogbone/Composite/build_roms.csh
+++ b/dogbone/Composite/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -423,7 +423,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/dogbone/Composite/build_roms.sh
+++ b/dogbone/Composite/build_roms.sh
@@ -270,7 +270,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/dogbone/Composite/build_roms.sh
+++ b/dogbone/Composite/build_roms.sh
@@ -344,6 +344,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/dogbone/Composite/build_roms.sh
+++ b/dogbone/Composite/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/dogbone/Composite/cbuild_roms.csh
+++ b/dogbone/Composite/cbuild_roms.csh
@@ -267,6 +267,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/dogbone/Composite/cbuild_roms.csh
+++ b/dogbone/Composite/cbuild_roms.csh
@@ -391,29 +391,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -621,9 +599,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -631,27 +609,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/dogbone/Composite/cbuild_roms.csh
+++ b/dogbone/Composite/cbuild_roms.csh
@@ -315,6 +315,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/dogbone/Composite/cbuild_roms.csh
+++ b/dogbone/Composite/cbuild_roms.csh
@@ -358,10 +358,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -562,7 +562,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/dogbone/Composite/cbuild_roms.sh
+++ b/dogbone/Composite/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -347,7 +347,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -537,7 +537,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/dogbone/Composite/cbuild_roms.sh
+++ b/dogbone/Composite/cbuild_roms.sh
@@ -377,29 +377,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -590,20 +568,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/dogbone/Composite/cbuild_roms.sh
+++ b/dogbone/Composite/cbuild_roms.sh
@@ -265,6 +265,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/dogbone/Composite/cbuild_roms.sh
+++ b/dogbone/Composite/cbuild_roms.sh
@@ -301,6 +301,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/dogbone/Refined/build_roms.csh
+++ b/dogbone/Refined/build_roms.csh
@@ -269,7 +269,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/dogbone/Refined/build_roms.csh
+++ b/dogbone/Refined/build_roms.csh
@@ -343,6 +343,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/dogbone/Refined/build_roms.csh
+++ b/dogbone/Refined/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -423,7 +423,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/dogbone/Refined/build_roms.sh
+++ b/dogbone/Refined/build_roms.sh
@@ -270,7 +270,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/dogbone/Refined/build_roms.sh
+++ b/dogbone/Refined/build_roms.sh
@@ -344,6 +344,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/dogbone/Refined/build_roms.sh
+++ b/dogbone/Refined/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/dogbone/Refined/cbuild_roms.csh
+++ b/dogbone/Refined/cbuild_roms.csh
@@ -267,6 +267,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/dogbone/Refined/cbuild_roms.csh
+++ b/dogbone/Refined/cbuild_roms.csh
@@ -391,29 +391,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -621,9 +599,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -631,27 +609,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/dogbone/Refined/cbuild_roms.csh
+++ b/dogbone/Refined/cbuild_roms.csh
@@ -315,6 +315,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/dogbone/Refined/cbuild_roms.csh
+++ b/dogbone/Refined/cbuild_roms.csh
@@ -358,10 +358,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -562,7 +562,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/dogbone/Refined/cbuild_roms.sh
+++ b/dogbone/Refined/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -347,7 +347,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -537,7 +537,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/dogbone/Refined/cbuild_roms.sh
+++ b/dogbone/Refined/cbuild_roms.sh
@@ -377,29 +377,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -590,20 +568,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/dogbone/Refined/cbuild_roms.sh
+++ b/dogbone/Refined/cbuild_roms.sh
@@ -265,6 +265,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/dogbone/Refined/cbuild_roms.sh
+++ b/dogbone/Refined/cbuild_roms.sh
@@ -301,6 +301,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/dogbone/Whole/build_roms.csh
+++ b/dogbone/Whole/build_roms.csh
@@ -268,7 +268,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/dogbone/Whole/build_roms.csh
+++ b/dogbone/Whole/build_roms.csh
@@ -342,6 +342,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/dogbone/Whole/build_roms.csh
+++ b/dogbone/Whole/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -422,7 +422,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/dogbone/Whole/build_roms.sh
+++ b/dogbone/Whole/build_roms.sh
@@ -343,6 +343,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/dogbone/Whole/build_roms.sh
+++ b/dogbone/Whole/build_roms.sh
@@ -269,7 +269,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/dogbone/Whole/build_roms.sh
+++ b/dogbone/Whole/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -423,7 +423,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/dogbone/Whole/cbuild_roms.csh
+++ b/dogbone/Whole/cbuild_roms.csh
@@ -266,6 +266,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/dogbone/Whole/cbuild_roms.csh
+++ b/dogbone/Whole/cbuild_roms.csh
@@ -390,29 +390,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -620,9 +598,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -630,27 +608,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/dogbone/Whole/cbuild_roms.csh
+++ b/dogbone/Whole/cbuild_roms.csh
@@ -357,10 +357,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -561,7 +561,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/dogbone/Whole/cbuild_roms.csh
+++ b/dogbone/Whole/cbuild_roms.csh
@@ -314,6 +314,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/dogbone/Whole/cbuild_roms.sh
+++ b/dogbone/Whole/cbuild_roms.sh
@@ -376,29 +376,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -589,20 +567,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/dogbone/Whole/cbuild_roms.sh
+++ b/dogbone/Whole/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DOGBONE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -346,7 +346,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -536,7 +536,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/dogbone/Whole/cbuild_roms.sh
+++ b/dogbone/Whole/cbuild_roms.sh
@@ -300,6 +300,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/dogbone/Whole/cbuild_roms.sh
+++ b/dogbone/Whole/cbuild_roms.sh
@@ -264,6 +264,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/AFTE/build_roms.csh
+++ b/double_gyre/AFTE/build_roms.csh
@@ -261,7 +261,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/AFTE/build_roms.csh
+++ b/double_gyre/AFTE/build_roms.csh
@@ -335,6 +335,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/double_gyre/AFTE/build_roms.csh
+++ b/double_gyre/AFTE/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/double_gyre/AFTE/build_roms.sh
+++ b/double_gyre/AFTE/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -416,7 +416,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/double_gyre/AFTE/build_roms.sh
+++ b/double_gyre/AFTE/build_roms.sh
@@ -262,7 +262,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/AFTE/build_roms.sh
+++ b/double_gyre/AFTE/build_roms.sh
@@ -336,6 +336,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/double_gyre/AFTE/cbuild_roms.csh
+++ b/double_gyre/AFTE/cbuild_roms.csh
@@ -259,6 +259,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/AFTE/cbuild_roms.csh
+++ b/double_gyre/AFTE/cbuild_roms.csh
@@ -383,29 +383,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -613,9 +591,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -623,27 +601,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/double_gyre/AFTE/cbuild_roms.csh
+++ b/double_gyre/AFTE/cbuild_roms.csh
@@ -307,6 +307,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/double_gyre/AFTE/cbuild_roms.csh
+++ b/double_gyre/AFTE/cbuild_roms.csh
@@ -350,10 +350,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -554,7 +554,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/double_gyre/AFTE/cbuild_roms.sh
+++ b/double_gyre/AFTE/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=OUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -339,7 +339,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -529,7 +529,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/double_gyre/AFTE/cbuild_roms.sh
+++ b/double_gyre/AFTE/cbuild_roms.sh
@@ -257,6 +257,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/AFTE/cbuild_roms.sh
+++ b/double_gyre/AFTE/cbuild_roms.sh
@@ -369,29 +369,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -582,20 +560,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/double_gyre/AFTE/cbuild_roms.sh
+++ b/double_gyre/AFTE/cbuild_roms.sh
@@ -293,6 +293,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/double_gyre/FSV/build_roms.csh
+++ b/double_gyre/FSV/build_roms.csh
@@ -261,7 +261,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/FSV/build_roms.csh
+++ b/double_gyre/FSV/build_roms.csh
@@ -335,6 +335,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/double_gyre/FSV/build_roms.csh
+++ b/double_gyre/FSV/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/double_gyre/FSV/build_roms.sh
+++ b/double_gyre/FSV/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -416,7 +416,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/double_gyre/FSV/build_roms.sh
+++ b/double_gyre/FSV/build_roms.sh
@@ -262,7 +262,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/FSV/build_roms.sh
+++ b/double_gyre/FSV/build_roms.sh
@@ -336,6 +336,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/double_gyre/FSV/cbuild_roms.csh
+++ b/double_gyre/FSV/cbuild_roms.csh
@@ -259,6 +259,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/FSV/cbuild_roms.csh
+++ b/double_gyre/FSV/cbuild_roms.csh
@@ -383,29 +383,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -613,9 +591,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -623,27 +601,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/double_gyre/FSV/cbuild_roms.csh
+++ b/double_gyre/FSV/cbuild_roms.csh
@@ -307,6 +307,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/double_gyre/FSV/cbuild_roms.csh
+++ b/double_gyre/FSV/cbuild_roms.csh
@@ -350,10 +350,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -554,7 +554,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/double_gyre/FSV/cbuild_roms.sh
+++ b/double_gyre/FSV/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -339,7 +339,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -529,7 +529,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/double_gyre/FSV/cbuild_roms.sh
+++ b/double_gyre/FSV/cbuild_roms.sh
@@ -257,6 +257,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/FSV/cbuild_roms.sh
+++ b/double_gyre/FSV/cbuild_roms.sh
@@ -369,29 +369,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -582,20 +560,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/double_gyre/FSV/cbuild_roms.sh
+++ b/double_gyre/FSV/cbuild_roms.sh
@@ -293,6 +293,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/double_gyre/FTE/build_roms.csh
+++ b/double_gyre/FTE/build_roms.csh
@@ -261,7 +261,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/FTE/build_roms.csh
+++ b/double_gyre/FTE/build_roms.csh
@@ -335,6 +335,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/double_gyre/FTE/build_roms.csh
+++ b/double_gyre/FTE/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/double_gyre/FTE/build_roms.sh
+++ b/double_gyre/FTE/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -416,7 +416,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/double_gyre/FTE/build_roms.sh
+++ b/double_gyre/FTE/build_roms.sh
@@ -262,7 +262,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/FTE/build_roms.sh
+++ b/double_gyre/FTE/build_roms.sh
@@ -336,6 +336,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/double_gyre/FTE/cbuild_roms.csh
+++ b/double_gyre/FTE/cbuild_roms.csh
@@ -259,6 +259,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/FTE/cbuild_roms.csh
+++ b/double_gyre/FTE/cbuild_roms.csh
@@ -383,29 +383,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -613,9 +591,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -623,27 +601,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/double_gyre/FTE/cbuild_roms.csh
+++ b/double_gyre/FTE/cbuild_roms.csh
@@ -307,6 +307,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/double_gyre/FTE/cbuild_roms.csh
+++ b/double_gyre/FTE/cbuild_roms.csh
@@ -350,10 +350,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -554,7 +554,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/double_gyre/FTE/cbuild_roms.sh
+++ b/double_gyre/FTE/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -220,7 +220,7 @@ export     MY_PROJECT_DIR=${PWD}
  export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DCHECKPOINTING"
  export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DSOLVE3D"
  export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DSALINITY"
- export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DNONLIN_EOS" 
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DNONLIN_EOS"
 
 #--------------------------------------------------------------------------
 # Compilation options.
@@ -339,7 +339,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -529,7 +529,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/double_gyre/FTE/cbuild_roms.sh
+++ b/double_gyre/FTE/cbuild_roms.sh
@@ -257,6 +257,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/FTE/cbuild_roms.sh
+++ b/double_gyre/FTE/cbuild_roms.sh
@@ -369,29 +369,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -582,20 +560,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/double_gyre/FTE/cbuild_roms.sh
+++ b/double_gyre/FTE/cbuild_roms.sh
@@ -293,6 +293,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/double_gyre/Forward/build_roms.csh
+++ b/double_gyre/Forward/build_roms.csh
@@ -338,6 +338,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/double_gyre/Forward/build_roms.csh
+++ b/double_gyre/Forward/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -418,7 +418,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/double_gyre/Forward/build_roms.csh
+++ b/double_gyre/Forward/build_roms.csh
@@ -264,7 +264,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/Forward/build_roms.sh
+++ b/double_gyre/Forward/build_roms.sh
@@ -339,6 +339,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/double_gyre/Forward/build_roms.sh
+++ b/double_gyre/Forward/build_roms.sh
@@ -265,7 +265,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/Forward/build_roms.sh
+++ b/double_gyre/Forward/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -419,7 +419,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/double_gyre/Forward/cbuild_roms.csh
+++ b/double_gyre/Forward/cbuild_roms.csh
@@ -262,6 +262,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/Forward/cbuild_roms.csh
+++ b/double_gyre/Forward/cbuild_roms.csh
@@ -386,29 +386,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -616,9 +594,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -626,27 +604,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/double_gyre/Forward/cbuild_roms.csh
+++ b/double_gyre/Forward/cbuild_roms.csh
@@ -353,10 +353,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -557,7 +557,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/double_gyre/Forward/cbuild_roms.csh
+++ b/double_gyre/Forward/cbuild_roms.csh
@@ -310,6 +310,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/double_gyre/Forward/cbuild_roms.sh
+++ b/double_gyre/Forward/cbuild_roms.sh
@@ -296,6 +296,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/double_gyre/Forward/cbuild_roms.sh
+++ b/double_gyre/Forward/cbuild_roms.sh
@@ -260,6 +260,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/Forward/cbuild_roms.sh
+++ b/double_gyre/Forward/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -342,7 +342,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -532,7 +532,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/double_gyre/Forward/cbuild_roms.sh
+++ b/double_gyre/Forward/cbuild_roms.sh
@@ -372,29 +372,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -585,20 +563,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/double_gyre/OP/build_roms.csh
+++ b/double_gyre/OP/build_roms.csh
@@ -261,7 +261,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/OP/build_roms.csh
+++ b/double_gyre/OP/build_roms.csh
@@ -335,6 +335,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/double_gyre/OP/build_roms.csh
+++ b/double_gyre/OP/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/double_gyre/OP/build_roms.sh
+++ b/double_gyre/OP/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -416,7 +416,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/double_gyre/OP/build_roms.sh
+++ b/double_gyre/OP/build_roms.sh
@@ -262,7 +262,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/OP/build_roms.sh
+++ b/double_gyre/OP/build_roms.sh
@@ -336,6 +336,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/double_gyre/OP/cbuild_roms.csh
+++ b/double_gyre/OP/cbuild_roms.csh
@@ -259,6 +259,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/OP/cbuild_roms.csh
+++ b/double_gyre/OP/cbuild_roms.csh
@@ -383,29 +383,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -613,9 +591,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -623,27 +601,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/double_gyre/OP/cbuild_roms.csh
+++ b/double_gyre/OP/cbuild_roms.csh
@@ -307,6 +307,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/double_gyre/OP/cbuild_roms.csh
+++ b/double_gyre/OP/cbuild_roms.csh
@@ -350,10 +350,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -554,7 +554,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/double_gyre/OP/cbuild_roms.sh
+++ b/double_gyre/OP/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -339,7 +339,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -529,7 +529,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/double_gyre/OP/cbuild_roms.sh
+++ b/double_gyre/OP/cbuild_roms.sh
@@ -257,6 +257,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/OP/cbuild_roms.sh
+++ b/double_gyre/OP/cbuild_roms.sh
@@ -369,29 +369,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -582,20 +560,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/double_gyre/OP/cbuild_roms.sh
+++ b/double_gyre/OP/cbuild_roms.sh
@@ -293,6 +293,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/double_gyre/SOsemi/build_roms.csh
+++ b/double_gyre/SOsemi/build_roms.csh
@@ -336,6 +336,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/double_gyre/SOsemi/build_roms.csh
+++ b/double_gyre/SOsemi/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -416,7 +416,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/double_gyre/SOsemi/build_roms.csh
+++ b/double_gyre/SOsemi/build_roms.csh
@@ -262,7 +262,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/SOsemi/build_roms.sh
+++ b/double_gyre/SOsemi/build_roms.sh
@@ -263,7 +263,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/double_gyre/SOsemi/build_roms.sh
+++ b/double_gyre/SOsemi/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -417,7 +417,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/double_gyre/SOsemi/build_roms.sh
+++ b/double_gyre/SOsemi/build_roms.sh
@@ -337,6 +337,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/double_gyre/SOsemi/cbuild_roms.csh
+++ b/double_gyre/SOsemi/cbuild_roms.csh
@@ -260,6 +260,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/double_gyre/SOsemi/cbuild_roms.csh
+++ b/double_gyre/SOsemi/cbuild_roms.csh
@@ -308,6 +308,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/double_gyre/SOsemi/cbuild_roms.csh
+++ b/double_gyre/SOsemi/cbuild_roms.csh
@@ -351,10 +351,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -555,7 +555,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/double_gyre/SOsemi/cbuild_roms.csh
+++ b/double_gyre/SOsemi/cbuild_roms.csh
@@ -384,29 +384,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -614,9 +592,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -624,27 +602,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/double_gyre/SOsemi/cbuild_roms.sh
+++ b/double_gyre/SOsemi/cbuild_roms.sh
@@ -294,6 +294,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/double_gyre/SOsemi/cbuild_roms.sh
+++ b/double_gyre/SOsemi/cbuild_roms.sh
@@ -370,29 +370,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -583,20 +561,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/double_gyre/SOsemi/cbuild_roms.sh
+++ b/double_gyre/SOsemi/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=DOUBLE_GYRE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -340,7 +340,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -530,7 +530,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/double_gyre/SOsemi/cbuild_roms.sh
+++ b/double_gyre/SOsemi/cbuild_roms.sh
@@ -258,6 +258,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/estuary_test/build_roms.csh
+++ b/estuary_test/build_roms.csh
@@ -138,7 +138,7 @@ end
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -417,7 +417,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/estuary_test/build_roms.csh
+++ b/estuary_test/build_roms.csh
@@ -263,7 +263,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/estuary_test/build_roms.csh
+++ b/estuary_test/build_roms.csh
@@ -337,6 +337,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/estuary_test/build_roms.sh
+++ b/estuary_test/build_roms.sh
@@ -338,6 +338,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/estuary_test/build_roms.sh
+++ b/estuary_test/build_roms.sh
@@ -264,7 +264,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/estuary_test/build_roms.sh
+++ b/estuary_test/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=ESTUARY_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -418,7 +418,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/estuary_test/cbuild_roms.csh
+++ b/estuary_test/cbuild_roms.csh
@@ -352,10 +352,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -556,7 +556,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/estuary_test/cbuild_roms.csh
+++ b/estuary_test/cbuild_roms.csh
@@ -309,6 +309,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/estuary_test/cbuild_roms.csh
+++ b/estuary_test/cbuild_roms.csh
@@ -261,6 +261,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/estuary_test/cbuild_roms.csh
+++ b/estuary_test/cbuild_roms.csh
@@ -385,29 +385,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -615,9 +593,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -625,27 +603,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/estuary_test/cbuild_roms.sh
+++ b/estuary_test/cbuild_roms.sh
@@ -295,6 +295,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/estuary_test/cbuild_roms.sh
+++ b/estuary_test/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=ESTUARY_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -341,7 +341,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -531,7 +531,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/estuary_test/cbuild_roms.sh
+++ b/estuary_test/cbuild_roms.sh
@@ -371,29 +371,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -584,20 +562,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/estuary_test/cbuild_roms.sh
+++ b/estuary_test/cbuild_roms.sh
@@ -259,6 +259,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/flt_test/build_roms.csh
+++ b/flt_test/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      FLT_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -414,7 +414,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/flt_test/build_roms.csh
+++ b/flt_test/build_roms.csh
@@ -334,6 +334,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/flt_test/build_roms.csh
+++ b/flt_test/build_roms.csh
@@ -260,7 +260,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/flt_test/build_roms.sh
+++ b/flt_test/build_roms.sh
@@ -261,7 +261,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/flt_test/build_roms.sh
+++ b/flt_test/build_roms.sh
@@ -335,6 +335,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/flt_test/build_roms.sh
+++ b/flt_test/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=FLT_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/flt_test/cbuild_roms.csh
+++ b/flt_test/cbuild_roms.csh
@@ -349,10 +349,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -553,7 +553,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/flt_test/cbuild_roms.csh
+++ b/flt_test/cbuild_roms.csh
@@ -382,29 +382,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -612,9 +590,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -622,27 +600,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/flt_test/cbuild_roms.csh
+++ b/flt_test/cbuild_roms.csh
@@ -306,6 +306,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/flt_test/cbuild_roms.csh
+++ b/flt_test/cbuild_roms.csh
@@ -258,6 +258,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/flt_test/cbuild_roms.sh
+++ b/flt_test/cbuild_roms.sh
@@ -292,6 +292,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/flt_test/cbuild_roms.sh
+++ b/flt_test/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=FLT_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -219,7 +219,7 @@ export     MY_PROJECT_DIR=${PWD}
 #export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DPOSITIVE_ZERO"
 
  export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DSOLVE3D -DANA_SSFLUX -DANA_BSFLUX"
- export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DSALINITY" 
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DSALINITY"
 
 #--------------------------------------------------------------------------
 # Compilation options.
@@ -338,7 +338,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -528,7 +528,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/flt_test/cbuild_roms.sh
+++ b/flt_test/cbuild_roms.sh
@@ -368,29 +368,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -581,20 +559,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/flt_test/cbuild_roms.sh
+++ b/flt_test/cbuild_roms.sh
@@ -256,6 +256,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/grav_adj/build_roms.csh
+++ b/grav_adj/build_roms.csh
@@ -266,7 +266,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/grav_adj/build_roms.csh
+++ b/grav_adj/build_roms.csh
@@ -340,6 +340,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/grav_adj/build_roms.csh
+++ b/grav_adj/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      GRAV_ADJ
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -420,7 +420,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/grav_adj/build_roms.sh
+++ b/grav_adj/build_roms.sh
@@ -338,6 +338,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/grav_adj/build_roms.sh
+++ b/grav_adj/build_roms.sh
@@ -264,7 +264,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/grav_adj/build_roms.sh
+++ b/grav_adj/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=GRAV_ADJ
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -418,7 +418,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/grav_adj/cbuild_roms.csh
+++ b/grav_adj/cbuild_roms.csh
@@ -264,6 +264,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/grav_adj/cbuild_roms.csh
+++ b/grav_adj/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/grav_adj/cbuild_roms.csh
+++ b/grav_adj/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/grav_adj/cbuild_roms.csh
+++ b/grav_adj/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/grav_adj/cbuild_roms.sh
+++ b/grav_adj/cbuild_roms.sh
@@ -295,6 +295,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/grav_adj/cbuild_roms.sh
+++ b/grav_adj/cbuild_roms.sh
@@ -371,29 +371,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -584,20 +562,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/grav_adj/cbuild_roms.sh
+++ b/grav_adj/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=GRAV_ADJ
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -341,7 +341,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -531,7 +531,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/grav_adj/cbuild_roms.sh
+++ b/grav_adj/cbuild_roms.sh
@@ -259,6 +259,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/inlet_test/build_roms.csh
+++ b/inlet_test/build_roms.csh
@@ -270,7 +270,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/inlet_test/build_roms.csh
+++ b/inlet_test/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      INLET_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/inlet_test/build_roms.csh
+++ b/inlet_test/build_roms.csh
@@ -344,6 +344,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/inlet_test/build_roms.sh
+++ b/inlet_test/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=INLET_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -425,7 +425,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/inlet_test/build_roms.sh
+++ b/inlet_test/build_roms.sh
@@ -271,7 +271,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/inlet_test/build_roms.sh
+++ b/inlet_test/build_roms.sh
@@ -345,6 +345,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/inlet_test/cbuild_roms.csh
+++ b/inlet_test/cbuild_roms.csh
@@ -392,29 +392,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -622,9 +600,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -632,27 +610,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/inlet_test/cbuild_roms.csh
+++ b/inlet_test/cbuild_roms.csh
@@ -316,6 +316,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/inlet_test/cbuild_roms.csh
+++ b/inlet_test/cbuild_roms.csh
@@ -359,10 +359,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -563,7 +563,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/inlet_test/cbuild_roms.csh
+++ b/inlet_test/cbuild_roms.csh
@@ -268,6 +268,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/inlet_test/cbuild_roms.sh
+++ b/inlet_test/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=INLET_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -348,7 +348,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -538,7 +538,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/inlet_test/cbuild_roms.sh
+++ b/inlet_test/cbuild_roms.sh
@@ -302,6 +302,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/inlet_test/cbuild_roms.sh
+++ b/inlet_test/cbuild_roms.sh
@@ -266,6 +266,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/inlet_test/cbuild_roms.sh
+++ b/inlet_test/cbuild_roms.sh
@@ -378,29 +378,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -591,20 +569,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/kelvin/build_roms.csh
+++ b/kelvin/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      KELVIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -416,7 +416,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/kelvin/build_roms.csh
+++ b/kelvin/build_roms.csh
@@ -336,6 +336,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/kelvin/build_roms.csh
+++ b/kelvin/build_roms.csh
@@ -262,7 +262,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/kelvin/build_roms.sh
+++ b/kelvin/build_roms.sh
@@ -263,7 +263,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/kelvin/build_roms.sh
+++ b/kelvin/build_roms.sh
@@ -337,6 +337,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/kelvin/build_roms.sh
+++ b/kelvin/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=KELVIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -417,7 +417,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/kelvin/cbuild_roms.csh
+++ b/kelvin/cbuild_roms.csh
@@ -260,6 +260,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/kelvin/cbuild_roms.csh
+++ b/kelvin/cbuild_roms.csh
@@ -308,6 +308,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/kelvin/cbuild_roms.csh
+++ b/kelvin/cbuild_roms.csh
@@ -351,10 +351,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -555,7 +555,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/kelvin/cbuild_roms.csh
+++ b/kelvin/cbuild_roms.csh
@@ -384,29 +384,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -614,9 +592,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -624,27 +602,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/kelvin/cbuild_roms.sh
+++ b/kelvin/cbuild_roms.sh
@@ -294,6 +294,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/kelvin/cbuild_roms.sh
+++ b/kelvin/cbuild_roms.sh
@@ -370,29 +370,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -583,20 +561,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/kelvin/cbuild_roms.sh
+++ b/kelvin/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=KELVIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -221,7 +221,7 @@ export     MY_PROJECT_DIR=${PWD}
  export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DDIAGNOSTICS_TS"
  export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DDIAGNOSTICS_UV"
 
- export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DRADIATION_2D" 
+ export      MY_CPP_FLAGS="${MY_CPP_FLAGS} -DRADIATION_2D"
 
 #--------------------------------------------------------------------------
 # Compilation options.
@@ -340,7 +340,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -530,7 +530,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/kelvin/cbuild_roms.sh
+++ b/kelvin/cbuild_roms.sh
@@ -258,6 +258,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/lab_canyon/build_roms.csh
+++ b/lab_canyon/build_roms.csh
@@ -334,6 +334,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/lab_canyon/build_roms.csh
+++ b/lab_canyon/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      LAB_CANYON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -414,7 +414,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/lab_canyon/build_roms.csh
+++ b/lab_canyon/build_roms.csh
@@ -260,7 +260,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/lab_canyon/build_roms.sh
+++ b/lab_canyon/build_roms.sh
@@ -261,7 +261,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/lab_canyon/build_roms.sh
+++ b/lab_canyon/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=LAB_CANYON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/lab_canyon/build_roms.sh
+++ b/lab_canyon/build_roms.sh
@@ -335,6 +335,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/lab_canyon/cbuild_roms.csh
+++ b/lab_canyon/cbuild_roms.csh
@@ -349,10 +349,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -553,7 +553,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/lab_canyon/cbuild_roms.csh
+++ b/lab_canyon/cbuild_roms.csh
@@ -382,29 +382,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -612,9 +590,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -622,27 +600,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/lab_canyon/cbuild_roms.csh
+++ b/lab_canyon/cbuild_roms.csh
@@ -306,6 +306,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/lab_canyon/cbuild_roms.csh
+++ b/lab_canyon/cbuild_roms.csh
@@ -258,6 +258,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/lab_canyon/cbuild_roms.sh
+++ b/lab_canyon/cbuild_roms.sh
@@ -292,6 +292,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/lab_canyon/cbuild_roms.sh
+++ b/lab_canyon/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=LAB_CANYON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -338,7 +338,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -528,7 +528,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/lab_canyon/cbuild_roms.sh
+++ b/lab_canyon/cbuild_roms.sh
@@ -368,29 +368,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -581,20 +559,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/lab_canyon/cbuild_roms.sh
+++ b/lab_canyon/cbuild_roms.sh
@@ -256,6 +256,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/lake_jersey/Forward/build_roms.csh
+++ b/lake_jersey/Forward/build_roms.csh
@@ -271,7 +271,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/lake_jersey/Forward/build_roms.csh
+++ b/lake_jersey/Forward/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      LAKE_JERSEY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}

--- a/lake_jersey/Forward/build_roms.csh
+++ b/lake_jersey/Forward/build_roms.csh
@@ -345,6 +345,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/lake_jersey/Forward/build_roms.sh
+++ b/lake_jersey/Forward/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=LAKE_JERSEY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -427,7 +427,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/lake_jersey/Forward/build_roms.sh
+++ b/lake_jersey/Forward/build_roms.sh
@@ -272,7 +272,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/lake_jersey/Forward/build_roms.sh
+++ b/lake_jersey/Forward/build_roms.sh
@@ -346,6 +346,20 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
+# If necessary, create ROMS build directory.
+
+if [ ! -d ${BUILD_DIR} ]; then
+  echo ""
+  echo "Creating ROMS build directory: ${BUILD_DIR}"
+  echo ""
+  mkdir $BUILD_DIR
+fi
+
 # Go to the users source directory to compile. The options set above will
 # pick up the application-specific code from the appropriate place.
 

--- a/lake_jersey/Forward/cbuild_roms.csh
+++ b/lake_jersey/Forward/cbuild_roms.csh
@@ -317,6 +317,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/lake_jersey/Forward/cbuild_roms.csh
+++ b/lake_jersey/Forward/cbuild_roms.csh
@@ -393,29 +393,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -623,9 +601,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -633,27 +611,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/lake_jersey/Forward/cbuild_roms.csh
+++ b/lake_jersey/Forward/cbuild_roms.csh
@@ -269,6 +269,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/lake_jersey/Forward/cbuild_roms.csh
+++ b/lake_jersey/Forward/cbuild_roms.csh
@@ -360,10 +360,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -564,7 +564,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/lake_jersey/Forward/cbuild_roms.sh
+++ b/lake_jersey/Forward/cbuild_roms.sh
@@ -267,6 +267,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/lake_jersey/Forward/cbuild_roms.sh
+++ b/lake_jersey/Forward/cbuild_roms.sh
@@ -379,29 +379,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -592,20 +570,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/lake_jersey/Forward/cbuild_roms.sh
+++ b/lake_jersey/Forward/cbuild_roms.sh
@@ -303,6 +303,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/lake_jersey/Forward/cbuild_roms.sh
+++ b/lake_jersey/Forward/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=LAKE_JERSEY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -349,7 +349,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -539,7 +539,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/lake_jersey/Refined/build_roms.csh
+++ b/lake_jersey/Refined/build_roms.csh
@@ -348,6 +348,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/lake_jersey/Refined/build_roms.csh
+++ b/lake_jersey/Refined/build_roms.csh
@@ -274,7 +274,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/lake_jersey/Refined/build_roms.csh
+++ b/lake_jersey/Refined/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      LAKE_JERSEY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -428,7 +428,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/lake_jersey/Refined/build_roms.sh
+++ b/lake_jersey/Refined/build_roms.sh
@@ -349,6 +349,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/lake_jersey/Refined/build_roms.sh
+++ b/lake_jersey/Refined/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=LAKE_JERSEY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -429,7 +429,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/lake_jersey/Refined/build_roms.sh
+++ b/lake_jersey/Refined/build_roms.sh
@@ -275,7 +275,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/lake_jersey/Refined/cbuild_roms.csh
+++ b/lake_jersey/Refined/cbuild_roms.csh
@@ -363,10 +363,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -567,7 +567,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/lake_jersey/Refined/cbuild_roms.csh
+++ b/lake_jersey/Refined/cbuild_roms.csh
@@ -396,29 +396,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -626,9 +604,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -636,27 +614,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/lake_jersey/Refined/cbuild_roms.csh
+++ b/lake_jersey/Refined/cbuild_roms.csh
@@ -320,6 +320,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/lake_jersey/Refined/cbuild_roms.csh
+++ b/lake_jersey/Refined/cbuild_roms.csh
@@ -272,6 +272,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/lake_jersey/Refined/cbuild_roms.sh
+++ b/lake_jersey/Refined/cbuild_roms.sh
@@ -382,29 +382,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -595,20 +573,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/lake_jersey/Refined/cbuild_roms.sh
+++ b/lake_jersey/Refined/cbuild_roms.sh
@@ -270,6 +270,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/lake_jersey/Refined/cbuild_roms.sh
+++ b/lake_jersey/Refined/cbuild_roms.sh
@@ -306,6 +306,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/lake_jersey/Refined/cbuild_roms.sh
+++ b/lake_jersey/Refined/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=LAKE_JERSEY
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -352,7 +352,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -542,7 +542,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/lmd_test/build_roms.csh
+++ b/lmd_test/build_roms.csh
@@ -334,6 +334,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/lmd_test/build_roms.csh
+++ b/lmd_test/build_roms.csh
@@ -260,7 +260,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/lmd_test/build_roms.csh
+++ b/lmd_test/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      LMD_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -414,7 +414,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/lmd_test/build_roms.sh
+++ b/lmd_test/build_roms.sh
@@ -261,7 +261,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/lmd_test/build_roms.sh
+++ b/lmd_test/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=LMD_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/lmd_test/build_roms.sh
+++ b/lmd_test/build_roms.sh
@@ -335,6 +335,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/lmd_test/cbuild_roms.csh
+++ b/lmd_test/cbuild_roms.csh
@@ -349,10 +349,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -553,7 +553,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/lmd_test/cbuild_roms.csh
+++ b/lmd_test/cbuild_roms.csh
@@ -382,29 +382,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -612,9 +590,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -622,27 +600,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/lmd_test/cbuild_roms.csh
+++ b/lmd_test/cbuild_roms.csh
@@ -306,6 +306,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/lmd_test/cbuild_roms.csh
+++ b/lmd_test/cbuild_roms.csh
@@ -258,6 +258,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/lmd_test/cbuild_roms.sh
+++ b/lmd_test/cbuild_roms.sh
@@ -292,6 +292,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/lmd_test/cbuild_roms.sh
+++ b/lmd_test/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=LMD_TEST
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -338,7 +338,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -528,7 +528,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/lmd_test/cbuild_roms.sh
+++ b/lmd_test/cbuild_roms.sh
@@ -368,29 +368,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -581,20 +559,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/lmd_test/cbuild_roms.sh
+++ b/lmd_test/cbuild_roms.sh
@@ -256,6 +256,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/riverplume/build_roms.csh
+++ b/riverplume/build_roms.csh
@@ -347,6 +347,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/riverplume/build_roms.csh
+++ b/riverplume/build_roms.csh
@@ -273,7 +273,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/riverplume/build_roms.csh
+++ b/riverplume/build_roms.csh
@@ -139,7 +139,7 @@ end
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -427,7 +427,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/riverplume/build_roms.sh
+++ b/riverplume/build_roms.sh
@@ -348,6 +348,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/riverplume/build_roms.sh
+++ b/riverplume/build_roms.sh
@@ -274,7 +274,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/riverplume/build_roms.sh
+++ b/riverplume/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -140,9 +140,9 @@ done
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -428,7 +428,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/riverplume/cbuild_roms.csh
+++ b/riverplume/cbuild_roms.csh
@@ -363,10 +363,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -567,7 +567,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/riverplume/cbuild_roms.csh
+++ b/riverplume/cbuild_roms.csh
@@ -396,29 +396,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -626,9 +604,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -636,27 +614,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/riverplume/cbuild_roms.csh
+++ b/riverplume/cbuild_roms.csh
@@ -320,6 +320,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/riverplume/cbuild_roms.csh
+++ b/riverplume/cbuild_roms.csh
@@ -272,6 +272,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/riverplume/cbuild_roms.sh
+++ b/riverplume/cbuild_roms.sh
@@ -148,7 +148,7 @@ done
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -351,7 +351,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -541,7 +541,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/riverplume/cbuild_roms.sh
+++ b/riverplume/cbuild_roms.sh
@@ -269,6 +269,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/riverplume/cbuild_roms.sh
+++ b/riverplume/cbuild_roms.sh
@@ -381,29 +381,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -594,20 +572,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/riverplume/cbuild_roms.sh
+++ b/riverplume/cbuild_roms.sh
@@ -305,6 +305,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/seamount/build_roms.csh
+++ b/seamount/build_roms.csh
@@ -334,6 +334,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/seamount/build_roms.csh
+++ b/seamount/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      SEAMOUNT
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -414,7 +414,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/seamount/build_roms.csh
+++ b/seamount/build_roms.csh
@@ -260,7 +260,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/seamount/build_roms.sh
+++ b/seamount/build_roms.sh
@@ -261,7 +261,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/seamount/build_roms.sh
+++ b/seamount/build_roms.sh
@@ -335,6 +335,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/seamount/build_roms.sh
+++ b/seamount/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=SEAMOUNT
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/seamount/cbuild_roms.csh
+++ b/seamount/cbuild_roms.csh
@@ -349,10 +349,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -553,7 +553,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/seamount/cbuild_roms.csh
+++ b/seamount/cbuild_roms.csh
@@ -382,29 +382,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -612,9 +590,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -622,27 +600,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/seamount/cbuild_roms.csh
+++ b/seamount/cbuild_roms.csh
@@ -306,6 +306,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/seamount/cbuild_roms.csh
+++ b/seamount/cbuild_roms.csh
@@ -258,6 +258,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/seamount/cbuild_roms.sh
+++ b/seamount/cbuild_roms.sh
@@ -292,6 +292,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/seamount/cbuild_roms.sh
+++ b/seamount/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=SEAMOUNT
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -338,7 +338,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -528,7 +528,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/seamount/cbuild_roms.sh
+++ b/seamount/cbuild_roms.sh
@@ -368,29 +368,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -581,20 +559,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/seamount/cbuild_roms.sh
+++ b/seamount/cbuild_roms.sh
@@ -256,6 +256,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/sed_test/build_roms.csh
+++ b/sed_test/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      SED_TEST1
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -414,7 +414,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/sed_test/build_roms.csh
+++ b/sed_test/build_roms.csh
@@ -334,6 +334,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/sed_test/build_roms.csh
+++ b/sed_test/build_roms.csh
@@ -260,7 +260,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/sed_test/build_roms.sh
+++ b/sed_test/build_roms.sh
@@ -261,7 +261,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/sed_test/build_roms.sh
+++ b/sed_test/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=SED_TEST1
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/sed_test/build_roms.sh
+++ b/sed_test/build_roms.sh
@@ -335,6 +335,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/sed_test/cbuild_roms.csh
+++ b/sed_test/cbuild_roms.csh
@@ -382,29 +382,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -612,9 +590,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -622,27 +600,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/sed_test/cbuild_roms.csh
+++ b/sed_test/cbuild_roms.csh
@@ -306,6 +306,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/sed_test/cbuild_roms.csh
+++ b/sed_test/cbuild_roms.csh
@@ -221,7 +221,7 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DPOSITIVE_ZERO"
 
 #setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DGLS_MIXING"
- setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DMY25_MIXING" 
+ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DMY25_MIXING"
 
 #--------------------------------------------------------------------------
 # Compilation options.
@@ -349,10 +349,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -553,7 +553,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/sed_test/cbuild_roms.csh
+++ b/sed_test/cbuild_roms.csh
@@ -258,6 +258,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/sed_test/cbuild_roms.sh
+++ b/sed_test/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=SED_TEST1
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -338,7 +338,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -528,7 +528,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/sed_test/cbuild_roms.sh
+++ b/sed_test/cbuild_roms.sh
@@ -292,6 +292,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/sed_test/cbuild_roms.sh
+++ b/sed_test/cbuild_roms.sh
@@ -368,29 +368,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -581,20 +559,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/sed_test/cbuild_roms.sh
+++ b/sed_test/cbuild_roms.sh
@@ -256,6 +256,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/shoreface/build_roms.csh
+++ b/shoreface/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      SHOREFACE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR         ${ROMS_ROOT_DIR}
@@ -445,7 +445,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/shoreface/build_roms.csh
+++ b/shoreface/build_roms.csh
@@ -365,6 +365,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/shoreface/build_roms.csh
+++ b/shoreface/build_roms.csh
@@ -291,7 +291,7 @@ setenv   MY_PROJECT_DIR      ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/shoreface/build_roms.sh
+++ b/shoreface/build_roms.sh
@@ -288,7 +288,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/shoreface/build_roms.sh
+++ b/shoreface/build_roms.sh
@@ -362,6 +362,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/shoreface/build_roms.sh
+++ b/shoreface/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=SHOREFACE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -442,7 +442,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/shoreface/cbuild_roms.csh
+++ b/shoreface/cbuild_roms.csh
@@ -286,6 +286,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/shoreface/cbuild_roms.csh
+++ b/shoreface/cbuild_roms.csh
@@ -334,6 +334,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/shoreface/cbuild_roms.csh
+++ b/shoreface/cbuild_roms.csh
@@ -249,7 +249,7 @@ setenv MY_PROJECT_DIR        ${PWD}
  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DMY25_MIXING"
 
  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DUV_QDRAG"
-#setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DSSW_BBL" 
+#setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -DSSW_BBL"
 
 #--------------------------------------------------------------------------
 # Compilation options.
@@ -377,10 +377,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -581,7 +581,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/shoreface/cbuild_roms.csh
+++ b/shoreface/cbuild_roms.csh
@@ -410,29 +410,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -640,9 +618,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -650,27 +628,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/shoreface/cbuild_roms.sh
+++ b/shoreface/cbuild_roms.sh
@@ -395,29 +395,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -608,20 +586,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/shoreface/cbuild_roms.sh
+++ b/shoreface/cbuild_roms.sh
@@ -283,6 +283,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/shoreface/cbuild_roms.sh
+++ b/shoreface/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=SHOREFACE
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -365,7 +365,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -555,7 +555,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/shoreface/cbuild_roms.sh
+++ b/shoreface/cbuild_roms.sh
@@ -319,6 +319,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/soliton/Forward/build_roms.csh
+++ b/soliton/Forward/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      SOLITON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -416,7 +416,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/soliton/Forward/build_roms.csh
+++ b/soliton/Forward/build_roms.csh
@@ -336,6 +336,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/soliton/Forward/build_roms.csh
+++ b/soliton/Forward/build_roms.csh
@@ -262,7 +262,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/soliton/Forward/build_roms.sh
+++ b/soliton/Forward/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=SOLITON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -417,7 +417,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/soliton/Forward/build_roms.sh
+++ b/soliton/Forward/build_roms.sh
@@ -263,7 +263,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/soliton/Forward/build_roms.sh
+++ b/soliton/Forward/build_roms.sh
@@ -337,6 +337,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/soliton/Forward/cbuild_roms.csh
+++ b/soliton/Forward/cbuild_roms.csh
@@ -260,6 +260,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/soliton/Forward/cbuild_roms.csh
+++ b/soliton/Forward/cbuild_roms.csh
@@ -308,6 +308,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/soliton/Forward/cbuild_roms.csh
+++ b/soliton/Forward/cbuild_roms.csh
@@ -351,10 +351,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -555,7 +555,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/soliton/Forward/cbuild_roms.csh
+++ b/soliton/Forward/cbuild_roms.csh
@@ -384,29 +384,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -614,9 +592,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -624,27 +602,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/soliton/Forward/cbuild_roms.sh
+++ b/soliton/Forward/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=SOLITON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -340,7 +340,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -530,7 +530,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/soliton/Forward/cbuild_roms.sh
+++ b/soliton/Forward/cbuild_roms.sh
@@ -294,6 +294,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/soliton/Forward/cbuild_roms.sh
+++ b/soliton/Forward/cbuild_roms.sh
@@ -370,29 +370,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -583,20 +561,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/soliton/Forward/cbuild_roms.sh
+++ b/soliton/Forward/cbuild_roms.sh
@@ -258,6 +258,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/soliton/Refined/build_roms.csh
+++ b/soliton/Refined/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      SOLITON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -432,7 +432,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/soliton/Refined/build_roms.csh
+++ b/soliton/Refined/build_roms.csh
@@ -352,6 +352,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/soliton/Refined/build_roms.csh
+++ b/soliton/Refined/build_roms.csh
@@ -278,7 +278,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/soliton/Refined/build_roms.sh
+++ b/soliton/Refined/build_roms.sh
@@ -351,6 +351,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/soliton/Refined/build_roms.sh
+++ b/soliton/Refined/build_roms.sh
@@ -277,7 +277,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/soliton/Refined/build_roms.sh
+++ b/soliton/Refined/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=SOLITON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -431,7 +431,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/soliton/Refined/cbuild_roms.csh
+++ b/soliton/Refined/cbuild_roms.csh
@@ -400,29 +400,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -630,9 +608,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -640,27 +618,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/soliton/Refined/cbuild_roms.csh
+++ b/soliton/Refined/cbuild_roms.csh
@@ -276,6 +276,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/soliton/Refined/cbuild_roms.csh
+++ b/soliton/Refined/cbuild_roms.csh
@@ -324,6 +324,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/soliton/Refined/cbuild_roms.csh
+++ b/soliton/Refined/cbuild_roms.csh
@@ -367,10 +367,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -571,7 +571,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/soliton/Refined/cbuild_roms.sh
+++ b/soliton/Refined/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=SOLITON
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -354,7 +354,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -544,7 +544,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/soliton/Refined/cbuild_roms.sh
+++ b/soliton/Refined/cbuild_roms.sh
@@ -384,29 +384,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -597,20 +575,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/soliton/Refined/cbuild_roms.sh
+++ b/soliton/Refined/cbuild_roms.sh
@@ -308,6 +308,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/soliton/Refined/cbuild_roms.sh
+++ b/soliton/Refined/cbuild_roms.sh
@@ -272,6 +272,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/test_chan/build_roms.csh
+++ b/test_chan/build_roms.csh
@@ -266,7 +266,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/test_chan/build_roms.csh
+++ b/test_chan/build_roms.csh
@@ -340,6 +340,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/test_chan/build_roms.csh
+++ b/test_chan/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      TEST_CHAN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -420,7 +420,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/test_chan/build_roms.sh
+++ b/test_chan/build_roms.sh
@@ -267,7 +267,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/test_chan/build_roms.sh
+++ b/test_chan/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=TEST_CHAN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -421,7 +421,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/test_chan/build_roms.sh
+++ b/test_chan/build_roms.sh
@@ -341,6 +341,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/test_chan/cbuild_roms.csh
+++ b/test_chan/cbuild_roms.csh
@@ -264,6 +264,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/test_chan/cbuild_roms.csh
+++ b/test_chan/cbuild_roms.csh
@@ -355,10 +355,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -559,7 +559,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/test_chan/cbuild_roms.csh
+++ b/test_chan/cbuild_roms.csh
@@ -312,6 +312,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/test_chan/cbuild_roms.csh
+++ b/test_chan/cbuild_roms.csh
@@ -388,29 +388,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -618,9 +596,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -628,27 +606,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/test_chan/cbuild_roms.sh
+++ b/test_chan/cbuild_roms.sh
@@ -374,29 +374,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -587,20 +565,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/test_chan/cbuild_roms.sh
+++ b/test_chan/cbuild_roms.sh
@@ -262,6 +262,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/test_chan/cbuild_roms.sh
+++ b/test_chan/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=TEST_CHAN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -344,7 +344,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -534,7 +534,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/test_chan/cbuild_roms.sh
+++ b/test_chan/cbuild_roms.sh
@@ -298,6 +298,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/test_head/build_roms.csh
+++ b/test_head/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      TEST_HEAD
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -458,7 +458,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/test_head/build_roms.csh
+++ b/test_head/build_roms.csh
@@ -378,6 +378,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/test_head/build_roms.csh
+++ b/test_head/build_roms.csh
@@ -304,7 +304,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/test_head/build_roms.sh
+++ b/test_head/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=TEST_HEAD
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -459,7 +459,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/test_head/build_roms.sh
+++ b/test_head/build_roms.sh
@@ -379,6 +379,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/test_head/build_roms.sh
+++ b/test_head/build_roms.sh
@@ -305,7 +305,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/test_head/cbuild_roms.csh
+++ b/test_head/cbuild_roms.csh
@@ -350,6 +350,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/test_head/cbuild_roms.csh
+++ b/test_head/cbuild_roms.csh
@@ -426,29 +426,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -656,9 +634,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -666,27 +644,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/test_head/cbuild_roms.csh
+++ b/test_head/cbuild_roms.csh
@@ -302,6 +302,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/test_head/cbuild_roms.csh
+++ b/test_head/cbuild_roms.csh
@@ -393,10 +393,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -597,7 +597,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/test_head/cbuild_roms.sh
+++ b/test_head/cbuild_roms.sh
@@ -334,6 +334,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/test_head/cbuild_roms.sh
+++ b/test_head/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=TEST_HEAD
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -380,7 +380,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -570,7 +570,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/test_head/cbuild_roms.sh
+++ b/test_head/cbuild_roms.sh
@@ -410,29 +410,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -623,20 +601,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/test_head/cbuild_roms.sh
+++ b/test_head/cbuild_roms.sh
@@ -298,6 +298,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/upwelling/build_roms.csh
+++ b/upwelling/build_roms.csh
@@ -288,7 +288,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/upwelling/build_roms.csh
+++ b/upwelling/build_roms.csh
@@ -362,6 +362,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/upwelling/build_roms.csh
+++ b/upwelling/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      UPWELLING
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -442,7 +442,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/upwelling/build_roms.sh
+++ b/upwelling/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=UPWELLING
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -439,7 +439,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/upwelling/build_roms.sh
+++ b/upwelling/build_roms.sh
@@ -285,7 +285,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/upwelling/build_roms.sh
+++ b/upwelling/build_roms.sh
@@ -359,6 +359,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/upwelling/cbuild_roms.csh
+++ b/upwelling/cbuild_roms.csh
@@ -286,6 +286,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/upwelling/cbuild_roms.csh
+++ b/upwelling/cbuild_roms.csh
@@ -377,10 +377,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -581,7 +581,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/upwelling/cbuild_roms.csh
+++ b/upwelling/cbuild_roms.csh
@@ -334,6 +334,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/upwelling/cbuild_roms.csh
+++ b/upwelling/cbuild_roms.csh
@@ -410,29 +410,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -640,9 +618,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -650,27 +628,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/upwelling/cbuild_roms.sh
+++ b/upwelling/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=UPWELLING
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -362,7 +362,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -552,7 +552,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/upwelling/cbuild_roms.sh
+++ b/upwelling/cbuild_roms.sh
@@ -392,29 +392,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -605,20 +583,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/upwelling/cbuild_roms.sh
+++ b/upwelling/cbuild_roms.sh
@@ -316,6 +316,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/upwelling/cbuild_roms.sh
+++ b/upwelling/cbuild_roms.sh
@@ -280,6 +280,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/weddell/build_roms.csh
+++ b/weddell/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WEDDELL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -423,7 +423,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/weddell/build_roms.csh
+++ b/weddell/build_roms.csh
@@ -269,7 +269,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/weddell/build_roms.csh
+++ b/weddell/build_roms.csh
@@ -343,6 +343,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/weddell/build_roms.sh
+++ b/weddell/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WEDDELL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -424,7 +424,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/weddell/build_roms.sh
+++ b/weddell/build_roms.sh
@@ -270,7 +270,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/weddell/build_roms.sh
+++ b/weddell/build_roms.sh
@@ -344,6 +344,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/weddell/cbuild_roms.csh
+++ b/weddell/cbuild_roms.csh
@@ -267,6 +267,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/weddell/cbuild_roms.csh
+++ b/weddell/cbuild_roms.csh
@@ -391,29 +391,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -621,9 +599,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -631,27 +609,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/weddell/cbuild_roms.csh
+++ b/weddell/cbuild_roms.csh
@@ -315,6 +315,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/weddell/cbuild_roms.csh
+++ b/weddell/cbuild_roms.csh
@@ -358,10 +358,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -562,7 +562,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/weddell/cbuild_roms.sh
+++ b/weddell/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WEDDELL
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -347,7 +347,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -537,7 +537,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/weddell/cbuild_roms.sh
+++ b/weddell/cbuild_roms.sh
@@ -377,29 +377,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -590,20 +568,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/weddell/cbuild_roms.sh
+++ b/weddell/cbuild_roms.sh
@@ -265,6 +265,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/weddell/cbuild_roms.sh
+++ b/weddell/cbuild_roms.sh
@@ -301,6 +301,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/windbasin/build_roms.csh
+++ b/windbasin/build_roms.csh
@@ -138,7 +138,7 @@ setenv ROMS_APPLICATION      WINDBASIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if ($?ROMS_ROOT_DIR) then
   setenv MY_ROOT_DIR        ${ROMS_ROOT_DIR}
@@ -414,7 +414,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-` 
+  set FFLAGS = `make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?MY_CPP_FLAGS) then

--- a/windbasin/build_roms.csh
+++ b/windbasin/build_roms.csh
@@ -334,6 +334,11 @@ else
   endif
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( ! -d $BUILD_DIR ) then

--- a/windbasin/build_roms.csh
+++ b/windbasin/build_roms.csh
@@ -260,7 +260,7 @@ setenv   MY_PROJECT_DIR     ${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-setenv WRF_SRC_DIR         ${HOME}/ocean/repository/WRF
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
 
 if ($?USE_DEBUG) then
   setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG

--- a/windbasin/build_roms.sh
+++ b/windbasin/build_roms.sh
@@ -261,7 +261,7 @@ export     MY_PROJECT_DIR=${PWD}
 # and cannot be moved when debugging with tools like TotalView.
 #--------------------------------------------------------------------------
 
-export        WRF_SRC_DIR=${HOME}/ocean/repository/WRF
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
 
 if [ -n "${USE_DEBUG:+1}" ]; then
   export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG

--- a/windbasin/build_roms.sh
+++ b/windbasin/build_roms.sh
@@ -103,7 +103,7 @@ do
       fi
       shift
       ;;
-      
+
     * )
       echo ""
       echo "${separator}"
@@ -139,9 +139,9 @@ export   ROMS_APPLICATION=WINDBASIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
-if [ -n "${ROMS_ROOT_DIR:+1}" ]; then 
+if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
 else
   export      MY_ROOT_DIR=${HOME}/ocean/repository/git
@@ -415,7 +415,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-` 
+  FFLAGS=`make print-FFLAGS | cut -d " " -f 3-`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if [ -n "${MY_CPP_FLAGS:+1}" ]; then

--- a/windbasin/build_roms.sh
+++ b/windbasin/build_roms.sh
@@ -335,6 +335,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ ! -d ${BUILD_DIR} ]; then

--- a/windbasin/cbuild_roms.csh
+++ b/windbasin/cbuild_roms.csh
@@ -349,10 +349,10 @@ if ( $dprint == 0 ) then
     echo ""
     cd src
     git checkout $branch_name
-  
+
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if ( ${COMPILERS} =~ ${MY_ROMS_SRC}* ) then
       setenv COMPILERS ${MY_PROJECT_DIR}/src/Compilers
     endif
@@ -553,7 +553,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   endif
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  set FFLAGS = `cat fortran_flags` 
+  set FFLAGS = `cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                 ${FFLAGS}"
   if ($?mycppflags) then

--- a/windbasin/cbuild_roms.csh
+++ b/windbasin/cbuild_roms.csh
@@ -382,29 +382,7 @@ setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${HEADER_DIR}"
 setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if ( -d ${MY_ROMS_SRC}/.git ) then
-  cd ${MY_ROMS_SRC}
-  set GITURL  = "`git config --get remote.origin.url`"
-  set GITREV  = "`git rev-parse --verify HEAD`"
-  set GIT_URL = "GIT_URL='${GITURL}'"
-  set GIT_REV = "GIT_REV='${GITREV}'"
-  set SVN_URL = "SVN_URL='https://www.myroms.org/svn/src'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${GIT_REV}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  set SVNURL  = "`svn info | grep '^URL:' | sed 's/URL: //'`"
-  set SVNREV  = "`svn info | grep '^Revision:' | sed 's/Revision: //'`"
-  set SVN_URL = "SVN_URL='${SVNURL}'"
-  set SVN_REV = "SVN_REV='${SVNREV}'"
-
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_URL}"
-  setenv MY_CPP_FLAGS "${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-endif
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -612,9 +590,9 @@ if ( $?ROMS_EXECUTABLE ) then
   endif
 endif
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
@@ -622,27 +600,27 @@ if ( $dprint == 0 ) then
   if ( ! $?ROMS_EXECUTABLE ) then
     if ( $?USE_DEBUG ) then
       if ( "${USE_DEBUG}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsG
+        cp -pfv ${BUILD_DIR}/romsG .
       endif
     else if ( $?USE_MPI ) then
       if ( "${USE_MPI}" == "on" ) then
-        ln -sfv ${BUILD_DIR}/romsM
+        cp -pfv ${BUILD_DIR}/romsM .
       endif
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     endif
   else
     if ( "${ROMS_EXECUTABLE}" == "ON" ) then
       if ( $?USE_DEBUG ) then
         if ( "${USE_DEBUG}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsG
+          cp -pfv ${BUILD_DIR}/romsG .
         endif
       else if ( $?USE_MPI ) then
         if ( "${USE_MPI}" == "on" ) then
-          ln -sfv ${BUILD_DIR}/romsM
+          cp -pfv ${BUILD_DIR}/romsM .
         endif
       else
-        ln -sfv ${BUILD_DIR}/romsS
+        cp -pfv ${BUILD_DIR}/romsS .
       endif
     endif
   endif

--- a/windbasin/cbuild_roms.csh
+++ b/windbasin/cbuild_roms.csh
@@ -306,6 +306,11 @@ else
   setenv BUILD_DIR           ${MY_PROJECT_DIR}/CBuild_roms
 endif
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+setenv SCRATCH_DIR ${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if ( $dprint == 0 ) then

--- a/windbasin/cbuild_roms.csh
+++ b/windbasin/cbuild_roms.csh
@@ -258,6 +258,34 @@ setenv MY_PROJECT_DIR        ${PWD}
 #setenv USE_HDF5             on              # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth Systems Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+setenv WRF_SRC_DIR         ${HOME}/ocean/repository/git/WRF
+
+if ($?USE_DEBUG) then
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_ciceG
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coampsG
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcmG
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wamG
+# setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrfG
+  setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+else
+  setenv CICE_LIB_DIR      ${MY_PROJECT_DIR}/Build_cice
+  setenv COAMPS_LIB_DIR    ${MY_PROJECT_DIR}/Build_coamps
+  setenv REGCM_LIB_DIR     ${MY_PROJECT_DIR}/Build_regcm
+  setenv WAM_LIB_DIR       ${MY_PROJECT_DIR}/Build_wam
+  setenv WRF_LIB_DIR       ${MY_PROJECT_DIR}/Build_wrf
+# setenv WRF_LIB_DIR       ${WRF_SRC_DIR}
+endif
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 

--- a/windbasin/cbuild_roms.sh
+++ b/windbasin/cbuild_roms.sh
@@ -292,6 +292,11 @@ else
   fi
 fi
 
+# For backward compatibility, set deprecated SCRATCH_DIR to compile
+# older released versions of ROMS.
+
+export SCRATCH_DIR=${BUILD_DIR}
+
 # If necessary, create ROMS build directory.
 
 if [ $dprint -eq 0 ]; then

--- a/windbasin/cbuild_roms.sh
+++ b/windbasin/cbuild_roms.sh
@@ -147,7 +147,7 @@ export   ROMS_APPLICATION=WINDBASIN
 # configuration and files are kept (MY_PROJECT_DIR). Notice that if the
 # User sets the ROMS_ROOT_DIR environment variable in their computer logging
 # script describing the location from where the ROMS source code was cloned
-# or downloaded, it uses that value. 
+# or downloaded, it uses that value.
 
 if [ -n "${ROMS_ROOT_DIR:+1}" ]; then
   export      MY_ROOT_DIR=${ROMS_ROOT_DIR}
@@ -338,7 +338,7 @@ if [ $dprint -eq 0 ]; then
 
     # If we are using the COMPILERS from the ROMS source code
     # overide the value set above
-  
+
     if [[ ${COMPILERS} == ${MY_ROMS_SRC}* ]]; then
       export COMPILERS=${MY_PROJECT_DIR}/src/Compilers
     fi
@@ -528,7 +528,7 @@ else
     echo "ROMS compiled branch:          $branch_name"
   fi
   echo "ROMS Application:              ${ROMS_APPLICATION}"
-  FFLAGS=`cat fortran_flags` 
+  FFLAGS=`cat fortran_flags`
   echo "Fortran compiler:              ${FORT}"
   echo "Fortran flags:                ${FFLAGS}"
   if [ -n "${mycppflags:+1}" ]; then

--- a/windbasin/cbuild_roms.sh
+++ b/windbasin/cbuild_roms.sh
@@ -368,29 +368,7 @@ export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ANALYTICAL_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${HEADER_DIR}"
 export       MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${ROOT_DIR}"
 
-if [[ -d "${MY_ROMS_SRC}/.git" ]]; then
-  cd ${MY_ROMS_SRC}
-  GITURL=$(git config --get remote.origin.url)
-  GITREV=$(git rev-parse --verify HEAD)
-  GIT_URL="GIT_URL='${GITURL}'"
-  GIT_REV="GIT_REV='${GITREV}'"
-  SVN_URL="SVN_URL='https://www.myroms.org/svn/src'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${GIT_REV}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  cd ${BUILD_DIR}
-else
-  cd ${MY_ROMS_SRC}
-  SVNURL=$(svn info | grep '^URL:' | sed 's/URL: //')
-  SVNREV=$(svn info | grep '^Revision:' | sed 's/Revision: //')
-  SVN_URL="SVN_URL='${SVNURL}'"
-  SVN_REV="SVN_REV='${SVNREV}'"
-
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_URL}"
-  export     MY_CPP_FLAGS="${MY_CPP_FLAGS} -D${SVN_REV}"
-  cd ${BUILD_DIR}
-fi
+cd ${BUILD_DIR}
 
 #--------------------------------------------------------------------------
 # Configure.
@@ -581,20 +559,20 @@ if [[ ! -z "${ROMS_EXECUTABLE}" && "${ROMS_EXECUTABLE}" == "OFF" ]]; then
   fi
 fi
 
-# Create symlink to executable. This should work even if ROMS was
-# linked to the shared library (libROMS.{so|dylib}) because
-# CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
+# Copy executable to project directory. This should work even
+# if ROMS was linked to the shared library (libROMS.{so|dylib})
+# because CMAKE_BUILD_WITH_INSTALL_RPATH is set to FALSE so that
 # RPATH/RUNPATH are set correctly for both the build tree and
 # installed locations of the ROMS executable.
 
 if [[ -z "${ROMS_EXECUTABLE}" || "${ROMS_EXECUTABLE}" == "ON" ]]; then
   if [ $dprint -eq 0 ]; then
     if [[ ! -z "${USE_DEBUG}" && "${USE_DEBUG}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsG
+      cp -pfv ${BUILD_DIR}/romsG .
     elif [[ ! -z "${USE_MPI}" && "${USE_MPI}" == "on" ]]; then
-      ln -sfv ${BUILD_DIR}/romsM
+      cp -pfv ${BUILD_DIR}/romsM .
     else
-      ln -sfv ${BUILD_DIR}/romsS
+      cp -pfv ${BUILD_DIR}/romsS .
     fi
   fi
 fi

--- a/windbasin/cbuild_roms.sh
+++ b/windbasin/cbuild_roms.sh
@@ -256,6 +256,34 @@ export     MY_PROJECT_DIR=${PWD}
 #export          USE_HDF5=on               # compile with HDF5 library
 
 #--------------------------------------------------------------------------
+# If coupling Earth System Models (ESM), set the location of the ESM
+# component libraries and modules. The strategy is to compile and link
+# each ESM component separately first, and then ROMS since it is driving
+# the coupled system. Only the ESM components activated are considered
+# and the rest are ignored.  Some components like WRF cannot be built
+# in a directory specified by the user but in its own root directory,
+# and cannot be moved when debugging with tools like TotalView.
+#--------------------------------------------------------------------------
+
+export        WRF_SRC_DIR=${HOME}/ocean/repository/git/WRF
+
+if [ -n "${USE_DEBUG:+1}" ]; then
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_ciceG
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coampsG
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcmG
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wamG
+# export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrfG
+  export      WRF_LIB_DIR=${WRF_SRC_DIR}
+else
+  export     CICE_LIB_DIR=${MY_PROJECT_DIR}/Build_cice
+  export   COAMPS_LIB_DIR=${MY_PROJECT_DIR}/Build_coamps
+  export    REGCM_LIB_DIR=${MY_PROJECT_DIR}/Build_regcm
+  export      WAM_LIB_DIR=${MY_PROJECT_DIR}/Build_wam
+  export      WRF_LIB_DIR=${MY_PROJECT_DIR}/Build_wrf
+# export      WRF_LIB_DIR=${WRF_SRC_DIR}
+fi
+
+#--------------------------------------------------------------------------
 # If applicable, use my specified library paths.
 #--------------------------------------------------------------------------
 


### PR DESCRIPTION
The **CMake** build scripts (**cbuild_roms.csh** and **cbuild_roms.sh**) were cleaned and made more compact:

 * For simplicity, Several macro definitions were moved from the build scripts to the ROMS main **CMakeLists.txt** configuration file.
 * The ROMS executable is now **copied** to the project directory instead of making a **symbolic** link. It should work even if ROMS were linked to the shared library (**libROMS.{so|dylib}**) because **CMAKE_BUILD_WITH_INSTALL_RPATH** is set to **FALSE** so that **RPATH/RUNPATH** are set correctly for both the build tree and installed locations of the ROMS executable.
 * The macro definitions in **Compilers/roms_compiler_flags.cmake** and **Compilers/roms_config.cmake** were also updated.