### PR TITLE
 Modeling 4D-Var Background Standard Deviation

### DIFF
--- a/IRENE/Coupled_RBL4DVAR/s4dvar.in
+++ b/IRENE/Coupled_RBL4DVAR/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/ARRAY_MODES/job_array_modes.csh
+++ b/WC13/ARRAY_MODES/job_array_modes.csh
@@ -76,6 +76,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -105,6 +110,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/ARRAY_MODES/s4dvar.in
+++ b/WC13/ARRAY_MODES/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/I4DVAR/job_i4dvar.csh
+++ b/WC13/I4DVAR/job_i4dvar.csh
@@ -50,6 +50,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set initial conditions, boundary conditions and surface forcing
 # error covariance normalization factors files.
 
@@ -77,6 +82,7 @@
  $SUBSTITUTE $I4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $I4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $I4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $I4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $I4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $I4DVAR roms_nrm_b.nc $NRMnameB
  $SUBSTITUTE $I4DVAR roms_nrm_f.nc $NRMnameF

--- a/WC13/I4DVAR/s4dvar.in
+++ b/WC13/I4DVAR/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/I4DVAR_analysis_impact/job_i4dvar_impact.csh
+++ b/WC13/I4DVAR_analysis_impact/job_i4dvar_impact.csh
@@ -63,6 +63,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set initial conditions, boundary conditions and surface forcing
 # error covariance normalization factors files.
 
@@ -90,6 +95,7 @@
  $SUBSTITUTE $I4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $I4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $I4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $I4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $I4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $I4DVAR roms_nrm_b.nc $NRMnameB
  $SUBSTITUTE $I4DVAR roms_nrm_f.nc $NRMnameF

--- a/WC13/I4DVAR_analysis_impact/s4dvar.in
+++ b/WC13/I4DVAR_analysis_impact/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/I4DVAR_split/s4dvar.in
+++ b/WC13/I4DVAR_split/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/Normalization/job_normalization.csh
+++ b/WC13/Normalization/job_normalization.csh
@@ -46,6 +46,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors filenames.
 
@@ -66,6 +71,7 @@
  $SUBSTITUTE $NORM roms_std_i.nc $STDnameI
  $SUBSTITUTE $NORM roms_std_b.nc $STDnameB
  $SUBSTITUTE $NORM roms_std_f.nc $STDnameF
+ $SUBSTITUTE $NORM roms_std_c.nc $STDnameC
  $SUBSTITUTE $NORM roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $NORM roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $NORM roms_nrm_b.nc $NRMnameB

--- a/WC13/Normalization/s4dvar.in
+++ b/WC13/Normalization/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/job_rbl4dvar.csh
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/job_rbl4dvar.csh
@@ -63,6 +63,11 @@
  set STDnameB=../../Data/wc13_std_b.nc
  set STDnameF=../../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -92,6 +97,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/RBL4DVAR/VERIFYING_ANALYSIS/s4dvar.in
+++ b/WC13/RBL4DVAR/VERIFYING_ANALYSIS/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR/job_rbl4dvar.csh
+++ b/WC13/RBL4DVAR/job_rbl4dvar.csh
@@ -52,6 +52,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -81,6 +86,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/RBL4DVAR/s4dvar.in
+++ b/WC13/RBL4DVAR/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_analysis_impact/job_rbl4dvar_impact.csh
+++ b/WC13/RBL4DVAR_analysis_impact/job_rbl4dvar_impact.csh
@@ -66,6 +66,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -95,6 +100,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/RBL4DVAR_analysis_impact/s4dvar.in
+++ b/WC13/RBL4DVAR_analysis_impact/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_analysis_sensitivity/job_rbl4dvar_sen.csh
+++ b/WC13/RBL4DVAR_analysis_sensitivity/job_rbl4dvar_sen.csh
@@ -66,6 +66,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -95,6 +100,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/RBL4DVAR_analysis_sensitivity/s4dvar.in
+++ b/WC13/RBL4DVAR_analysis_sensitivity/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_forecast_impact/FCSTA/s4dvar.in
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTA/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_forecast_impact/FCSTAT/s4dvar.in
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTAT/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_forecast_impact/FCSTB/s4dvar.in
+++ b/WC13/RBL4DVAR_forecast_impact/FCSTB/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_forecast_impact/job_rbl4dvar_fct_impact.csh
+++ b/WC13/RBL4DVAR_forecast_impact/job_rbl4dvar_fct_impact.csh
@@ -108,6 +108,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -137,6 +142,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/RBL4DVAR_forecast_impact/job_rbl4dvar_fct_impact_obs_space.csh
+++ b/WC13/RBL4DVAR_forecast_impact/job_rbl4dvar_fct_impact_obs_space.csh
@@ -105,6 +105,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -142,6 +147,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/RBL4DVAR_forecast_impact/s4dvar.in
+++ b/WC13/RBL4DVAR_forecast_impact/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/s4dvar.in
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTA/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/s4dvar.in
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTAT/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/s4dvar.in
+++ b/WC13/RBL4DVAR_forecast_sensitivity/FCSTB/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_forecast_sensitivity/job_rbl4dvar_fct_sen.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/job_rbl4dvar_fct_sen.csh
@@ -108,6 +108,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -137,6 +142,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/RBL4DVAR_forecast_sensitivity/job_rbl4dvar_fct_sen_obs_space.csh
+++ b/WC13/RBL4DVAR_forecast_sensitivity/job_rbl4dvar_fct_sen_obs_space.csh
@@ -105,6 +105,11 @@
  set STDnameB=../Data/wc13_std_b.nc
  set STDnameF=../Data/wc13_std_f.nc
 
+# Set output file for standard deviation computed/modeled from background
+# (prior) state.
+
+ set STDnameC=wc13_std_computed.nc
+
 # Set model, initial conditions, boundary conditions and surface
 # forcing error covariance normalization factors files.
 
@@ -142,6 +147,7 @@
  $SUBSTITUTE $RBL4DVAR roms_std_i.nc $STDnameI
  $SUBSTITUTE $RBL4DVAR roms_std_b.nc $STDnameB
  $SUBSTITUTE $RBL4DVAR roms_std_f.nc $STDnameF
+ $SUBSTITUTE $RBL4DVAR roms_std_c.nc $STDnameC
  $SUBSTITUTE $RBL4DVAR roms_nrm_m.nc $NRMnameM
  $SUBSTITUTE $RBL4DVAR roms_nrm_i.nc $NRMnameI
  $SUBSTITUTE $RBL4DVAR roms_nrm_b.nc $NRMnameB

--- a/WC13/RBL4DVAR_forecast_sensitivity/s4dvar.in
+++ b/WC13/RBL4DVAR_forecast_sensitivity/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.

--- a/WC13/RBL4DVAR_split/s4dvar.in
+++ b/WC13/RBL4DVAR_split/s4dvar.in
@@ -319,6 +319,36 @@ HdecayF(isUstr) == 100.0d+3                       ! surface U-momentum stress
 HdecayF(isVstr) == 100.0d+3                       ! surface V-momentum stress
 HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!
+! The Mogensen et al. (2012) formulation assumes that the background errors
+! are proportional to vertical derivatives of the state vector field. Its
+! error has the similar field profile shape, but the difference with its
+! ture error value is due to a vertical displacement.
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computes using the
+! criterion from kara et al. (2000). Otherwise, it will be set to uniform
+! value provided below.
+
+Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value
+
+Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
+ Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
+ Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean 
+ Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement
+
+Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
+ Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
+ Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean 
+ Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement
+
+Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
+ Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at mixed layer
+ Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in deep ocean 
+ Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement
+
+      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
+
 ! Select flag for BackGround Quality Control (BGQC) of observations:
 !
 !      [1] Quality control in terms of state variable indices
@@ -405,6 +435,13 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
        STDnameI == roms_std_i.nc
        STDnameB == roms_std_b.nc
        STDnameF == roms_std_f.nc
+
+! If computing the standard deviation from the background (prior) state
+! vector as an alternative to climatological values read from the
+! input NetCDF file, enter output standard deviation file name,
+! [1:Ngrids].
+
+       STDnameC == roms_std_c.nc
 
 ! Input/output model, initial conditions, boundary conditions, and surface
 ! forcing error covariance normalization factors file name, [1:Ngrids].
@@ -841,6 +878,34 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !                   HdecayF(isVstr)               wind V-stress
 !
 !------------------------------------------------------------------------------
+! Modeled standard deviation (STD) of Background Error Covarinace parameters.
+!------------------------------------------------------------------------------
+!
+! The user may activate STD_MODEL to compute the standard deviation directly
+! from the background (prior) field as an alternative to climatological values
+! read from the input NetCDF files. It follows the work of Mogensen et al.
+! (2012) by assuming the background errors are proportional to the vertical
+! derivatives of the background field. The field error has a similar profile
+! shape, but the difference with the actual error value is due to a vertical
+! displacement.
+!
+! The modeling of standard deviation (STD) uses the following parameters per
+! state field:
+!
+! Sigma_max(:)      Maximum STD value
+!
+! Sigma_ml(:)       Minimum STD at mixed layer
+!
+! Sigma_do(:)       Minimum STD in deep ocean 
+!
+! Sigma_dz(:)       Vertical profile displacement
+!
+! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
+! approach of Kara et al. (2000). Otherwise, a constant value is used.
+!
+! mld_uniform       Uniform mixed-layer depth value
+!
+!------------------------------------------------------------------------------
 ! Background Quality Control (BCQC) of observations parameters.
 !------------------------------------------------------------------------------
 !
@@ -944,6 +1009,9 @@ HdecayF(isTsur) == 100.0d+3  100.0d+3             ! 1:NT surface tracers flux
 !
 !  STDnameF       Input surface forcing error covariance
 !                   standard deviation file name.
+!
+!  STDnameC       Output standard deviation file name
+!                   computed from  background (prior) state
 !
 !  NRMnameM       Input/output model error covariance
 !                   normalization factors file name.


### PR DESCRIPTION
In 4D-Var, the background (prior) error covariance, **B**, is a large matrix that cannot be computed or stored directly. Still, its effects can be modeled using spatial correlations, **C**, and spatial convolutions via diffusion operators. To convert correlations into error covariance, we multiply by a diagonal matrix of the background error standard deviations, $\bf\Sigma$. Hence,

$$ \mathbf{B = K \Sigma C \Sigma^{T} K^{T}}$$

Here, **K** is a balance operator if **`BALANCE_OPERATOR`** is activated in **ROMS**. It allows the information on unobserved state variables to be extracted from directly observed quantities by imposing linear balance relationships between temperature and other state variables using **T-S** empirical formulas, the linear equation of state, hydrostatic balance, and geostrophic balance. Please check Moore _et al._ (2011) for more information.

This update includes an approach to computing the standard deviation,  $\bf\Sigma$, directly from the background state field as an alternative to climatological values read from the input NetCDF files. It follows the work of Mogensen _et al._ (2012) by assuming the background errors are proportional to the vertical derivatives of the background field. The background field's practical standard deviation shape has a vertical profile similar to its vertical derivative. For example, the difference between background (prior) temperature and actual temperature is due to a vertical displacement.

In the past, the standard deviation was read from input NetCDF files and computed from a long simulation of the **ROMS** application. The climatological $\bf\Sigma$ can be categorized as monthly, seasonal, or annual values.

The modeling of the standard deviation from the background (prior) is activated with the **`STD_MODEL`** option and done in the new module **`background_std.F`**. If you want more information about this capability in **ROMS**, please check Moore et al. (2020).

New parameters are added to 4D-Var input script **s4dvar.in** to constraint the standard deviation profile at the mixed-layer depth and deep ocean:

``` js
! Modeled standard deviation (STD) of Background Error Covariance parameters.
!
! The Mogensen et al. (2012) formulation assumes that the background errors
! are proportional to vertical derivatives of the state vector field. Its
! error has a similar field profile shape, but the difference with its
! ture error value is due to a vertical displacement.
!
! If COMPUTE_MLD is activated, the mixed-layer depth is computed using the
! criterion from Kara et al. (2000). Otherwise, it will be set to a uniform
! value provided below.

Sigma_max(isFsur) == 0.025d0           ! free surface  maximum STD value

Sigma_max(isUvel) == 0.06d0            ! U-velocity maximum STD value
 Sigma_ml(isUvel) == 0.05d0            ! U-velocity minimum STD at mixed layer
 Sigma_do(isUvel) == 0.02d0            ! U-velocity minimum STD in deep ocean
 Sigma_dz(isUvel) == 500.0d0           ! U-velocity vertical displacement

Sigma_max(isVvel) == 0.06d0            ! V-velocity maximum STD
 Sigma_ml(isVvel) == 0.05d0            ! V-velocity minimum STD at mixed layer
 Sigma_do(isVvel) == 0.02d0            ! V-velocity minimum STD in deep ocean
 Sigma_dz(isVvel) == 500.0d0           ! V-velocity vertical displacement

Sigma_max(isTvar) == 0.33d0   0.056d0  ! 1:NT tracers maximum STD
 Sigma_ml(isTvar) == 0.05d0   0.05d0   ! 1:NT tracers minimum STD at the mixed layer
 Sigma_do(isTvar) == 0.02d0   0.0028d0 ! 1:NT tracers minimum STD in the deep ocean
 Sigma_dz(isTvar) == 40.0d0   40.0d0   ! 1:NT tracer vertical displacement

      mld_uniform == -75.0d0           ! Uniform mixed layer depth value
``` 
Notice we have the option **`COMPUTE_MLD`** to compute the mixed-layer depth using the approach of Kara ''et al.'' (2000) or set a constant value with the **mld_uniform** input parameter.

----
Therefore, the difference between the background values of a 3D state variable $\phi_{b}$ and the true value $\phi_{t}$ is due to a vertical displacement $\delta{z}$ of the profile. Thus, to a first-order approximation
$$\phi_{t} \approx \phi_{b}(z+\delta{z}) + (\partial{\phi_{b}}/\partial{z}) $$
 
The error in $\phi_{b}$ is approximated by $(\partial{\phi_{b}}/\partial{z})\delta{z}$, and it is assumed that the **standard deviation** $\bf\Sigma$ is approximated by $\sigma_{\phi} \sim \mid(\partial{\phi_{b}}/\partial{z})\delta{z} \mid$, with the folllowing constraints:

$$ \sigma_{\phi} = \begin{cases} \hbox{\bf max}(\widehat{\sigma_{\phi}}, \enspace\sigma_{\phi}^{ml}),   &\text{if} \quad z \geq -D_{ml} \\ 
\hbox{\bf max}(\widehat{\sigma_{\phi}}, \enspace\sigma_{\phi}^{do}),  &\text{if}\quad z < -D_{ml}\end{cases} $$

where

$$ \widehat{\sigma_{\phi}} = \hbox{\bf min}(\mid(\partial{\phi_{b}}/\partial{z})\mid, \enspace\sigma_{\phi}^{max}) $$

Here, $\sigma_{\phi}^{max}$ is the maximum value of $\sigma_{\phi}$, prescribed as **`Sigma_max(:)`**, while $\sigma_{\phi}^{ml}$ and $\sigma_{\phi}^{do}$ are the minimum values in the mixed layer and deep ocean, prescribed as **`Sigma_ml(:)`** and **`Sigma_do(:)`**, respectively. The vertical displacemen $\delta{z}$ is specified in **`Sigma_dz(:)`**.

----
Two new routines are added, **`def_std.F`** and **`wrt_std.F`**, to write the standard deviation modeled from the background into an output NetCDF file. It will be needed in the split 4D-Var algorithms and for postprocessing. The new filename is also specified in **`s4dvar.in`**:

``` js
! If computing the standard deviation from the background (prior) state
! vector as an alternative to climatological values read from the
! input NetCDF file, enter the output standard deviation file name,
! [1:Ngrids].

       STDnameC == roms_std_c.nc
```

We foresee enhancing this capability in the future. We only model the standard deviation for adjusting the initial state vector (**zeta**, **u**, **v**, **T**, and **S**). We don't have options for background error on the model (weak constraint), lateral model boundary conditions, surface tracer fluxes, and surface momentum stress. Thus, those standard deviation values are still read from input files.

Notice that the standard deviation structure for I/O management increased its inner dimension from **4** to **5** in **`mod_iounits.F`**:

``` f90
       IF (.not.allocated(STD)) THEN
         allocate ( STD(5,Ngrids) )
       END IF
````

## WARNING:  ##

- The **`s4dvar.in`** has the additional parameters mentioned above. Please update your 4D-Var input script to use his new capability.

- The standard deviation modeling parameters in **`s4dvar.in`** are determined in a heuristic way. They are application-dependent since they are determined as a function of circulation variability where the largest errors are expected to occur in the thermocline, pycnocline, near the mixed-layer depth, and other processes. The values above are tuned for the ROMS 4D-Var default application, **`WC13`**.

- Notice that the normalization coefficients that ensure that the diagonal elements of **B** are equal to unity **do not** use the standard deviation in their computation when using the squared root of the diffusion operator. Therefore, you **do not** need to recompute them when using this alternative method to estimate **S**. However, as before, the normalization coefficients need to be recomputed only if:
  - The bathymetry is changed.
  - The land/sea masking is altered.
  - More importantly, if any of the decorrelation scales are modified.

----

## References: ##

- Kara A., P. Rochford, and E. Hulburt, 2000: An optimal definition for ocean mixed layer depth, ''J. Geophys. Res.'', **105**, NoC7, pp 16, 803-16, 821.

- Mogensen, K., M.A. Balmaseda, and A.T. Weaver, 2012: The NEMOVAR    ocean data assimilation system implemented in the ECMWF ocean analysis for system 4, ''ECMWF Tech. Memorandum 668'', **59**.

- Moore, A.M., H.G. Arango, G. Broquet, B.S. Powell, A.T. Weaver, and J. Zavala-Garay, 2011: The Regional Ocean Modeling System (ROMS)  4-dimensional variational data assimilations systems, Part I - System overview and formulation, ''Prog. Oceanogr.'', **91**, 34-49, https://doi:10.1016/j.pocean.2011.05.004.

- Moore, A., J. Zavala-Garay, H.G. Arango, C.A. Edwards, J. Anderson, and T. Hoar, 2020: Regional and basin scale applications of ensemble adjustment Kalman filter and 4D-Var ocean data assimilation systems, ''Progress in Oceanography'', **189**, 102450, https://doi.org/10.1016/j.pocean.2020.102450.