### PR TITLE
Adjust YAML files for the recent changes in UFS Coastal

### DIFF
--- a/IRENE/Coupling/roms_data_cdeps/roms_cdeps_era5.yaml
+++ b/IRENE/Coupling/roms_data_cdeps/roms_cdeps_era5.yaml
@@ -205,7 +205,7 @@ export:
 
 import:
 
-  - standard_name:       mean_down_lw_flx
+  - standard_name:       inst_down_lw_flx
     long_name:           surface downward longwave radiation flux
     short_name:          dLWrad                                 # Faxa_lwdn
     data_variables:      [lwrad_down, time]
@@ -235,7 +235,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_net_sw_flx
+  - standard_name:       inst_net_sw_flx
     long_name:           surface net shortwave radiation flux
     short_name:          SWrad                                  # Faxa_swnet
     data_variables:      [swrad_daily, time]
@@ -310,7 +310,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_prec_rate
+  - standard_name:       inst_prec_rate
     long_name:           precipitation rate
     short_name:          rain                                   # Faxa_rain
     data_variables:      [rain, time]

--- a/IRENE/Coupling/roms_data_cdeps/roms_cdeps_narr.yaml
+++ b/IRENE/Coupling/roms_data_cdeps/roms_cdeps_narr.yaml
@@ -205,7 +205,7 @@ export:
 
 import:
 
-  - standard_name:       mean_down_lw_flx
+  - standard_name:       inst_down_lw_flx
     long_name:           surface downward longwave radiation flux
     short_name:          dLWrad                                 # Faxa_lwdn
     data_variables:      [lwrad_down, time]
@@ -235,7 +235,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_net_sw_flx
+  - standard_name:       inst_net_sw_flx
     long_name:           surface net shortwave radiation flux
     short_name:          SWrad                                  # Faxa_swnet
     data_variables:      [swrad_daily, time]
@@ -310,7 +310,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_prec_rate
+  - standard_name:       inst_prec_rate
     long_name:           precipitation rate
     short_name:          rain                                   # Faxa_rain
     data_variables:      [rain, time]

--- a/IRENE/Coupling/roms_data_cmeps/roms_cmeps_era5.yaml
+++ b/IRENE/Coupling/roms_data_cmeps/roms_cmeps_era5.yaml
@@ -222,7 +222,7 @@ export:
 
 import:
 
-  - standard_name:       mean_down_lw_flx
+  - standard_name:       inst_down_lw_flx
     long_name:           surface downward longwave radiation flux
     short_name:          dLWrad                                 # Faxa_lwdn
     data_variables:      [lwrad_down, time]
@@ -252,7 +252,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_net_sw_flx
+  - standard_name:       inst_net_sw_flx
     long_name:           surface net shortwave radiation flux
     short_name:          SWrad                                  # Faxa_swnet
     data_variables:      [swrad_daily, time]
@@ -327,7 +327,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_prec_rate
+  - standard_name:       inst_prec_rate
     long_name:           precipitation rate
     short_name:          rain                                   # Faxa_rain
     data_variables:      [rain, time]

--- a/IRENE/Coupling/roms_data_cmeps/roms_cmeps_narr.yaml
+++ b/IRENE/Coupling/roms_data_cmeps/roms_cmeps_narr.yaml
@@ -207,7 +207,7 @@ export:
 
 import:
 
-  - standard_name:       mean_down_lw_flx
+  - standard_name:       inst_down_lw_flx
     long_name:           surface downward longwave radiation flux
     short_name:          dLWrad                                 # Faxa_lwdn
     data_variables:      [lwrad_down, time]
@@ -237,7 +237,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_net_sw_flx
+  - standard_name:       inst_net_sw_flx
     long_name:           surface net shortwave radiation flux
     short_name:          SWrad                                  # Faxa_swnet
     data_variables:      [swrad_daily, time]
@@ -312,7 +312,7 @@ import:
     map_type:            mapbilnr
     map_norm:            none
 
-  - standard_name:       mean_prec_rate
+  - standard_name:       inst_prec_rate
     long_name:           precipitation rate
     short_name:          rain                                   # Faxa_rain
     data_variables:      [rain, time]


### PR DESCRIPTION
This PR adjusts coupling YAML files of IRENE test case to work with UFS Coastal. The recent change in UFS Weather Model modified field dictionary and changed `mean` prefix of the some fields to `inst`. The change in here makes ROMS specific YAML files compatible with the recent changes in the UFS Weather Model 