### PR TITLE
Updated the arguments to stats_2dfld and stats_3dfld

### DIFF
--- a/lake_ice/Forward/ana_initial.h
+++ b/lake_ice/Forward/ana_initial.h
@@ -1,4 +1,4 @@
-!!
+!
       SUBROUTINE ana_initial (ng, tile, model)
 !
 !! git $Id$
@@ -199,6 +199,7 @@
       IF (first) THEN
         first=.FALSE.
         DO i=1,SIZE(Stats,1)
+          Stats(i) % checksum=0_i8b
           Stats(i) % count=0.0_r8
           Stats(i) % min=Large
           Stats(i) % max=-Large
@@ -237,14 +238,14 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(1),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(1), 0,            &
      &                  LBi, UBi, LBj, UBj, ubar(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idUbar))//': '//                 &
      &                    TRIM(Vname(1,idUbar)),                        &
      &                     ng, Stats(1)%min, Stats(1)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(2),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(2), 0,            &
      &                  LBi, UBi, LBj, UBj, vbar(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idVbar))//': '//                 &
@@ -272,7 +273,7 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3), 0,            &
      &                  LBi, UBi, LBj, UBj, zeta(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idFsur))//': '//                 &
@@ -316,14 +317,14 @@
 !
 !  Report statistics.
 !
-      CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(4),               &
+      CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(4), 0,            &
      &                  LBi, UBi, LBj, UBj, 1, N(ng), u(:,:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idUvel))//': '//                 &
      &                    TRIM(Vname(1,idUvel)),                        &
      &                    ng, Stats(4)%min, Stats(4)%max
       END IF
-      CALL stats_3dfld (ng, tile, iNLM, v3dvar, Stats(5),               &
+      CALL stats_3dfld (ng, tile, iNLM, v3dvar, Stats(5), 0,            &
      &                  LBi, UBi, LBj, UBj, 1, N(ng), v(:,:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idVvel))//': '//                 &
@@ -366,7 +367,7 @@
 !  Report statistics.
 !
       DO itrc=1,NAT
-        CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(itrc+5),        &
+        CALL stats_3dfld (ng, tile, iNLM, r3dvar, Stats(itrc+5), 0,     &
      &                    LBi, UBi, LBj, UBj, 1, N(ng), t(:,:,:,1,itrc))
         IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
           WRITE (stdout,10) TRIM(Vname(2,idTvar(itrc)))//': '//         &

--- a/soliton/Refined/ana_initial.h
+++ b/soliton/Refined/ana_initial.h
@@ -1,4 +1,4 @@
-!!
+!
       SUBROUTINE ana_initial (ng, tile, model)
 !
 !! git $Id$
@@ -116,6 +116,7 @@
       IF (first) THEN
         first=.FALSE.
         DO i=1,SIZE(Stats,1)
+          Stats(i) % checksum=0_i8b
           Stats(i) % count=0.0_r8
           Stats(i) % min=Large
           Stats(i) % max=-Large
@@ -182,14 +183,14 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(1),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(1), 0,            &
      &                  LBi, UBi, LBj, UBj, ubar(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idUbar))//': '//                 &
      &                    TRIM(Vname(1,idUbar)),                        &
      &                     ng, Stats(1)%min, Stats(1)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(2),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(2), 0,            &
      &                  LBi, UBi, LBj, UBj, vbar(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idVbar))//': '//                 &
@@ -235,7 +236,7 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3), 0,            &
      &                  LBi, UBi, LBj, UBj, zeta(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idFsur))//': '//                 &

--- a/upwelling/ana_humid.h
+++ b/upwelling/ana_humid.h
@@ -1,3 +1,4 @@
+!
       SUBROUTINE ana_humid (ng, tile, model)
 !
 !! git $Id$

--- a/upwelling/ana_initial.h
+++ b/upwelling/ana_initial.h
@@ -1,3 +1,4 @@
+!
       SUBROUTINE ana_initial (ng, tile, model)
 !
 !! git $Id$
@@ -157,7 +158,8 @@
       IF (first) THEN
         first=.FALSE.
         DO i=1,SIZE(Stats,1)
-          Stats(i) % count=0.0_r8
+          Stats(i) % checksum=0_i8b
+          Stats(i) % count=0
           Stats(i) % min=Large
           Stats(i) % max=-Large
           Stats(i) % avg=0.0_r8
@@ -182,14 +184,14 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(1),               &
+      CALL stats_2dfld (ng, tile, iNLM, u2dvar, Stats(1), 0,            &
      &                  LBi, UBi, LBj, UBj, ubar(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idUbar))//': '//                 &
      &                    TRIM(Vname(1,idUbar)),                        &
      &                     ng, Stats(1)%min, Stats(1)%max
       END IF
-      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(2),               &
+      CALL stats_2dfld (ng, tile, iNLM, v2dvar, Stats(2), 0,            &
      &                  LBi, UBi, LBj, UBj, vbar(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idVbar))//': '//                 &
@@ -209,7 +211,7 @@
 !
 !  Report statistics.
 !
-      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3),               &
+      CALL stats_2dfld (ng, tile, iNLM, r2dvar, Stats(3), 0,            &
      &                  LBi, UBi, LBj, UBj, zeta(:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idFsur))//': '//                 &
@@ -238,14 +240,14 @@
 !
 !  Report statistics.
 !
-      CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(4),               &
+      CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(4), 0,            &
      &                  LBi, UBi, LBj, UBj, 1, N(ng), u(:,:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idUvel))//': '//                 &
      &                    TRIM(Vname(1,idUvel)),                        &
      &                    ng, Stats(4)%min, Stats(4)%max
       END IF
-      CALL stats_3dfld (ng, tile, iNLM, v3dvar, Stats(5),               &
+      CALL stats_3dfld (ng, tile, iNLM, v3dvar, Stats(5), 0,            &
      &                  LBi, UBi, LBj, UBj, 1, N(ng), v(:,:,:,1))
       IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
         WRITE (stdout,10) TRIM(Vname(2,idVvel))//': '//                 &
@@ -296,7 +298,7 @@
 !  Report statistics.
 !
       DO itrc=1,NAT
-        CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(itrc+5),        &
+        CALL stats_3dfld (ng, tile, iNLM, r3dvar, Stats(itrc+5), 0,     &
      &                    LBi, UBi, LBj, UBj, 1, N(ng), t(:,:,:,1,itrc))
         IF (DOMAIN(ng)%NorthEast_Corner(tile)) THEN
           WRITE (stdout,10) TRIM(Vname(2,idTvar(itrc)))//': '//         &

--- a/upwelling/ana_pair.h
+++ b/upwelling/ana_pair.h
@@ -1,3 +1,4 @@
+!
       SUBROUTINE ana_pair (ng, tile, model)
 !
 !! git $Id$

--- a/upwelling/ana_winds.h
+++ b/upwelling/ana_winds.h
@@ -1,3 +1,4 @@
+!
       SUBROUTINE ana_winds (ng, tile, model)
 !
 !! git $Id$


### PR DESCRIPTION
Changes due to https://github.com/myroms/roms/pull/36:

- The derived type **`T_STATS`** structure includes an additional member checksum that must be initialized when computing the statistics. For example, in **`ana_initial.h`**, we must have:
``` f90
      IF (first) THEN
        first=.FALSE.
        DO i=1,SIZE(Stats,1)
          Stats(i) % checksum=0_i8b
          Stats(i) % count=0
          Stats(i) % min=Large
          Stats(i) % max=-Large
          Stats(i) % avg=0.0_r8
          Stats(i) % rms=0.0_r8
        END DO
      END IF
```
- The analytical routines needed an additional argument **Extract_Flag** when calling **`stats_2dfield,`** **`stats_3dfield`**, and **`stats_4dfield`** . For example, in **`ana_initial.h`**, we now have:
``` f90
      CALL stats_3dfld (ng, tile, iNLM, u3dvar, Stats(4), 0,            &
     &                  LBi, UBi, LBj, UBj, 1, N(ng), u(:,:,:,1))
```